### PR TITLE
Local development setup with docker-compose.dev.yml

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ See the minimal setup guide at `copilot/README.md`.
 
 ### Full local stack (recommended)
 
-Runs Postgres, Redis, Kafka, migrations, seed data, and both API services in one command:
+Runs Postgres, Redis, Kafka, migrations, seed data, both API services, and the Nuxt frontend in one command:
 
 ```shell
 docker compose -f docker-compose.dev.yml up -d
@@ -21,12 +21,15 @@ docker compose -f docker-compose.dev.yml up -d
 
 | Service     | URL                        |
 |-------------|----------------------------|
+| bidon-ui    | http://localhost:3010      |
 | bidon-admin | http://localhost:1323      |
 | bidon-sdkapi| http://localhost:1324      |
 | Postgres    | localhost:5434             |
 | Kafka       | localhost:9092             |
 
 **First run** requires internet access to pull images and download Go modules. Subsequent runs work offline once the module cache is warm.
+Frontend (`bidon-ui`) runs with file watching enabled for Docker and hot-reloads on changes under `web/bidon_ui/`.
+API requests from the frontend (`/api/**`, `/auth/**`) are proxied to `bidon-admin` automatically in this setup.
 
 To re-run migrations and seed data (e.g. after a reset):
 ```shell

--- a/README.md
+++ b/README.md
@@ -10,6 +10,39 @@ For detailed instructions on setting up a self-hosted instance of Bidon, visit o
 See the minimal setup guide at `copilot/README.md`.
 
 ## Set up development environment
+
+### Full local stack (recommended)
+
+Runs Postgres, Redis, Kafka, migrations, seed data, and both API services in one command:
+
+```shell
+docker compose -f docker-compose.dev.yml up -d
+```
+
+| Service     | URL                        |
+|-------------|----------------------------|
+| bidon-admin | http://localhost:1323      |
+| bidon-sdkapi| http://localhost:1324      |
+| Postgres    | localhost:5434             |
+| Kafka       | localhost:9092             |
+
+**First run** requires internet access to pull images and download Go modules. Subsequent runs work offline once the module cache is warm.
+
+To re-run migrations and seed data (e.g. after a reset):
+```shell
+docker compose -f docker-compose.dev.yml rm -f migrate bidon-seed && \
+docker compose -f docker-compose.dev.yml up -d
+```
+
+To tear down and remove all data:
+```shell
+docker compose -f docker-compose.dev.yml down --volumes --remove-orphans
+```
+
+### Manual setup (dependencies only)
+
+If you prefer to run the services directly on your machine:
+
 ```shell
 make local-init
 

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -1,0 +1,186 @@
+services:
+  postgres:
+    image: postgres:17-alpine
+    ports:
+      - '5434:5432'
+    volumes:
+      - pgdata-dev:/var/lib/postgresql/data
+    environment:
+      POSTGRES_DB: bidon
+      POSTGRES_USER: bidon
+      POSTGRES_PASSWORD: pass
+    healthcheck:
+      test: pg_isready -U bidon -d bidon
+      interval: 5s
+
+  redis:
+    build:
+      context: .
+      dockerfile: docker/redis/Dockerfile
+    ports:
+      - '7001-7003:7001-7003'
+    environment:
+      - REDIS_CLUSTER_START_PORT=7001
+      - REDIS_CLUSTER_ANNOUNCE_HOSTNAME=host.docker.internal
+    volumes:
+      - redis-data-dev:/data
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
+
+  zookeeper:
+    image: confluentinc/cp-zookeeper:7.2.1
+    hostname: zookeeper
+    healthcheck:
+      test: echo srvr | nc zookeeper 2181 || exit 1
+      retries: 20
+      interval: 10s
+    ports:
+      - '2181:2181'
+    environment:
+      ZOOKEEPER_CLIENT_PORT: 2181
+      ZOOKEEPER_TICK_TIME: 2000
+
+  kafka:
+    image: confluentinc/cp-kafka:7.2.1
+    hostname: kafka
+    depends_on:
+      - zookeeper
+    ports:
+      - '9092:9092'
+      - '9093:9093'
+    environment:
+      KAFKA_BROKER_ID: 1
+      KAFKA_ZOOKEEPER_CONNECT: 'zookeeper:2181'
+      KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: PLAINTEXT:PLAINTEXT,PLAINTEXT_INTERNAL:PLAINTEXT,EXTERNAL_DOCKER:PLAINTEXT
+      KAFKA_LISTENERS: PLAINTEXT://:9092,PLAINTEXT_INTERNAL://:29092,EXTERNAL_DOCKER://:9093
+      KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://localhost:9092,PLAINTEXT_INTERNAL://kafka:29092,EXTERNAL_DOCKER://host.docker.internal:9093
+      KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 1
+      KAFKA_GROUP_INITIAL_REBALANCE_DELAY_MS: 0
+      KAFKA_TRANSACTION_STATE_LOG_MIN_ISR: 1
+      KAFKA_TRANSACTION_STATE_LOG_REPLICATION_FACTOR: 1
+
+  migrate:
+    image: golang:1.24-alpine
+    volumes:
+      - .:/app
+      - gomodcache-dev:/go/pkg/mod
+      - gocache-dev:/root/.cache/go-build
+    working_dir: /app
+    command: go run ./cmd/bidon-migrate -no-gen up
+    depends_on:
+      postgres:
+        condition: service_healthy
+    environment:
+      ENVIRONMENT: development
+      DATABASE_URL: postgres://bidon:pass@postgres:5432/bidon
+      DATABASE_REPLICA_URL: postgres://bidon:pass@postgres:5432/bidon
+
+  bidon-seed:
+    image: golang:1.24-alpine
+    volumes:
+      - .:/app
+      - gomodcache-dev:/go/pkg/mod
+      - gocache-dev:/root/.cache/go-build
+    working_dir: /app
+    command: go run ./cmd/bidon-seed
+    depends_on:
+      migrate:
+        condition: service_completed_successfully
+    environment:
+      ENVIRONMENT: development
+      DATABASE_URL: postgres://bidon:pass@postgres:5432/bidon
+
+  bidon-admin:
+    image: golang:1.24-alpine
+    volumes:
+      - .:/app
+      - gomodcache-dev:/go/pkg/mod
+      - gocache-dev:/root/.cache/go-build
+    working_dir: /app
+    command: go run ./cmd/bidon-admin
+    ports:
+      - '1323:1323'
+      - '50051:50051'
+    depends_on:
+      migrate:
+        condition: service_completed_successfully
+      redis:
+        condition: service_started
+      kafka:
+        condition: service_started
+    environment:
+      PORT: 1323
+      GRPC_PORT: 50051
+      DATABASE_URL: postgres://bidon:pass@postgres:5432/bidon
+      DATABASE_REPLICA_URL: postgres://bidon:pass@postgres:5432/bidon
+      ENVIRONMENT: development
+      APP_SECRET: app_secret
+      SUPERUSER_LOGIN: login
+      SUPERUSER_PASSWORD: password
+      USE_GEOCODING: "false"
+      USE_KAFKA: "true"
+      KAFKA_BROKERS_LIST: kafka:29092
+      KAFKA_CLIENT_ID: bidon_dev
+      KAFKA_DELIVERY_INTERVAL: 5
+      KAFKA_AD_EVENTS_TOPIC: ad-events
+      KAFKA_NOTIFICATION_EVENTS_TOPIC: notification-events
+      REDIS_URL: redis://host.docker.internal:7001/0
+      REDIS_CLUSTER: host.docker.internal:7001,host.docker.internal:7002,host.docker.internal:7003
+      SNOWFLAKE_NODE_ID: 1
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
+
+  bidon-sdkapi:
+    image: golang:1.24-alpine
+    volumes:
+      - .:/app
+      - gomodcache-dev:/go/pkg/mod
+      - gocache-dev:/root/.cache/go-build
+    working_dir: /app
+    command: go run ./cmd/bidon-sdkapi
+    ports:
+      - '1324:1323'
+    depends_on:
+      migrate:
+        condition: service_completed_successfully
+      redis:
+        condition: service_started
+      kafka:
+        condition: service_started
+    environment:
+      PORT: 1323
+      DATABASE_URL: postgres://bidon:pass@postgres:5432/bidon
+      DATABASE_REPLICA_URL: postgres://bidon:pass@postgres:5432/bidon
+      ENVIRONMENT: development
+      APP_SECRET: app_secret
+      USE_GEOCODING: "false"
+      USE_KAFKA: "true"
+      KAFKA_BROKERS_LIST: kafka:29092
+      KAFKA_CLIENT_ID: bidon_dev
+      KAFKA_DELIVERY_INTERVAL: 5
+      KAFKA_AD_EVENTS_TOPIC: ad-events
+      KAFKA_NOTIFICATION_EVENTS_TOPIC: notification-events
+      REDIS_URL: redis://host.docker.internal:7001/0
+      REDIS_CLUSTER: host.docker.internal:7001,host.docker.internal:7002,host.docker.internal:7003
+      SNOWFLAKE_NODE_ID: 1
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
+
+  init-admin:
+    image: alpine/curl
+    depends_on:
+      bidon-admin:
+        condition: service_started
+    environment:
+      SUPERUSER_LOGIN: login
+      SUPERUSER_PASSWORD: password
+      BIDON_ADMIN_URL: http://bidon-admin:1323
+    volumes:
+      - ./scripts/init-admin.sh:/init-admin.sh
+    command: sh /init-admin.sh
+
+volumes:
+  pgdata-dev:
+  gomodcache-dev:
+  gocache-dev:
+  redis-data-dev:

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -1,3 +1,41 @@
+x-golang-dev-app-base: &golang-dev-app-base
+  volumes:
+    - .:/app
+    - gomodcache-dev:/go/pkg/mod
+    - gocache-dev:/root/.cache/go-build
+  working_dir: /app
+
+x-host-gateway-extra-hosts: &host-gateway-extra-hosts
+  - "host.docker.internal:host-gateway"
+
+x-dev-db-env: &dev-db-env
+  DATABASE_URL: postgres://bidon:pass@postgres:5432/bidon
+  DATABASE_REPLICA_URL: postgres://bidon:pass@postgres:5432/bidon
+
+x-dev-kafka-env: &dev-kafka-env
+  USE_KAFKA: "true"
+  KAFKA_BROKERS_LIST: kafka:29092
+  KAFKA_CLIENT_ID: bidon_dev
+  KAFKA_DELIVERY_INTERVAL: 5
+  KAFKA_AD_EVENTS_TOPIC: ad-events
+  KAFKA_NOTIFICATION_EVENTS_TOPIC: notification-events
+
+x-redis-cluster-env: &redis-cluster-env
+  REDIS_CLUSTER_START_PORT: 7001
+  REDIS_CLUSTER_ANNOUNCE_HOSTNAME: host.docker.internal
+  REDIS_URL: redis://host.docker.internal:7001/0
+  REDIS_CLUSTER: host.docker.internal:7001,host.docker.internal:7002,host.docker.internal:7003
+
+x-dev-bidon-app-env: &dev-bidon-app-env
+  <<: [*dev-kafka-env, *redis-cluster-env]
+  ENVIRONMENT: development
+  USE_GEOCODING: "false"
+  SNOWFLAKE_NODE_ID: 1
+
+x-dev-superuser-env: &dev-superuser-env
+  SUPERUSER_LOGIN: login
+  SUPERUSER_PASSWORD: password
+
 services:
   postgres:
     image: postgres:17-alpine
@@ -20,12 +58,10 @@ services:
     ports:
       - '7001-7003:7001-7003'
     environment:
-      - REDIS_CLUSTER_START_PORT=7001
-      - REDIS_CLUSTER_ANNOUNCE_HOSTNAME=host.docker.internal
+      <<: *redis-cluster-env
     volumes:
       - redis-data-dev:/data
-    extra_hosts:
-      - "host.docker.internal:host-gateway"
+    extra_hosts: *host-gateway-extra-hosts
 
   zookeeper:
     image: confluentinc/cp-zookeeper:7.2.1
@@ -61,42 +97,27 @@ services:
 
   migrate:
     image: golang:1.24-alpine
-    volumes:
-      - .:/app
-      - gomodcache-dev:/go/pkg/mod
-      - gocache-dev:/root/.cache/go-build
-    working_dir: /app
+    <<: *golang-dev-app-base
     command: go run ./cmd/bidon-migrate -no-gen up
     depends_on:
       postgres:
         condition: service_healthy
     environment:
-      ENVIRONMENT: development
-      DATABASE_URL: postgres://bidon:pass@postgres:5432/bidon
-      DATABASE_REPLICA_URL: postgres://bidon:pass@postgres:5432/bidon
+      <<: [*dev-db-env, *dev-bidon-app-env]
 
   bidon-seed:
     image: golang:1.24-alpine
-    volumes:
-      - .:/app
-      - gomodcache-dev:/go/pkg/mod
-      - gocache-dev:/root/.cache/go-build
-    working_dir: /app
+    <<: *golang-dev-app-base
     command: go run ./cmd/bidon-seed
     depends_on:
       migrate:
         condition: service_completed_successfully
     environment:
-      ENVIRONMENT: development
-      DATABASE_URL: postgres://bidon:pass@postgres:5432/bidon
+      <<: [*dev-db-env, *dev-bidon-app-env]
 
   bidon-admin:
     image: golang:1.24-alpine
-    volumes:
-      - .:/app
-      - gomodcache-dev:/go/pkg/mod
-      - gocache-dev:/root/.cache/go-build
-    working_dir: /app
+    <<: *golang-dev-app-base
     command: go run ./cmd/bidon-admin
     ports:
       - '1323:1323'
@@ -109,34 +130,15 @@ services:
       kafka:
         condition: service_started
     environment:
+      <<: [*dev-db-env, *dev-bidon-app-env, *dev-superuser-env]
       PORT: 1323
       GRPC_PORT: 50051
-      DATABASE_URL: postgres://bidon:pass@postgres:5432/bidon
-      DATABASE_REPLICA_URL: postgres://bidon:pass@postgres:5432/bidon
-      ENVIRONMENT: development
       APP_SECRET: app_secret
-      SUPERUSER_LOGIN: login
-      SUPERUSER_PASSWORD: password
-      USE_GEOCODING: "false"
-      USE_KAFKA: "true"
-      KAFKA_BROKERS_LIST: kafka:29092
-      KAFKA_CLIENT_ID: bidon_dev
-      KAFKA_DELIVERY_INTERVAL: 5
-      KAFKA_AD_EVENTS_TOPIC: ad-events
-      KAFKA_NOTIFICATION_EVENTS_TOPIC: notification-events
-      REDIS_URL: redis://host.docker.internal:7001/0
-      REDIS_CLUSTER: host.docker.internal:7001,host.docker.internal:7002,host.docker.internal:7003
-      SNOWFLAKE_NODE_ID: 1
-    extra_hosts:
-      - "host.docker.internal:host-gateway"
+    extra_hosts: *host-gateway-extra-hosts
 
   bidon-sdkapi:
     image: golang:1.24-alpine
-    volumes:
-      - .:/app
-      - gomodcache-dev:/go/pkg/mod
-      - gocache-dev:/root/.cache/go-build
-    working_dir: /app
+    <<: *golang-dev-app-base
     command: go run ./cmd/bidon-sdkapi
     ports:
       - '1324:1323'
@@ -148,23 +150,31 @@ services:
       kafka:
         condition: service_started
     environment:
+      <<: [*dev-db-env, *dev-bidon-app-env]
       PORT: 1323
-      DATABASE_URL: postgres://bidon:pass@postgres:5432/bidon
-      DATABASE_REPLICA_URL: postgres://bidon:pass@postgres:5432/bidon
-      ENVIRONMENT: development
       APP_SECRET: app_secret
-      USE_GEOCODING: "false"
-      USE_KAFKA: "true"
-      KAFKA_BROKERS_LIST: kafka:29092
-      KAFKA_CLIENT_ID: bidon_dev
-      KAFKA_DELIVERY_INTERVAL: 5
-      KAFKA_AD_EVENTS_TOPIC: ad-events
-      KAFKA_NOTIFICATION_EVENTS_TOPIC: notification-events
-      REDIS_URL: redis://host.docker.internal:7001/0
-      REDIS_CLUSTER: host.docker.internal:7001,host.docker.internal:7002,host.docker.internal:7003
-      SNOWFLAKE_NODE_ID: 1
-    extra_hosts:
-      - "host.docker.internal:host-gateway"
+    extra_hosts: *host-gateway-extra-hosts
+
+  bidon-ui:
+    image: node:22-alpine
+    working_dir: /workspace/web/bidon_ui
+    # Clear Nuxt's generated cache (`.nuxt`) so it regenerates against the container's `node_modules`
+    # (important when `node_modules` is mounted via a Docker volume).
+    command: sh -c "rm -rf .nuxt node_modules/.cache && yarn install --frozen-lockfile && yarn dev --hostname 0.0.0.0 --port 3010"
+    ports:
+      - '3010:3010'
+    depends_on:
+      bidon-admin:
+        condition: service_started
+    environment:
+      NUXT_API_PROXY_TARGET: http://bidon-admin:1323
+      # Force polling-based file watching so host file edits are reliably detected in Docker.
+      CHOKIDAR_USEPOLLING: "true"
+      # Enable polling in webpack/watchpack dependencies used by Nuxt/Vite plugin tooling.
+      WATCHPACK_POLLING: "true"
+    volumes:
+      - .:/workspace
+      - bidon-ui-node-modules-dev:/workspace/web/bidon_ui/node_modules
 
   init-admin:
     image: alpine/curl
@@ -172,8 +182,7 @@ services:
       bidon-admin:
         condition: service_started
     environment:
-      SUPERUSER_LOGIN: login
-      SUPERUSER_PASSWORD: password
+      <<: *dev-superuser-env
       BIDON_ADMIN_URL: http://bidon-admin:1323
     volumes:
       - ./scripts/init-admin.sh:/init-admin.sh
@@ -184,3 +193,4 @@ volumes:
   gomodcache-dev:
   gocache-dev:
   redis-data-dev:
+  bidon-ui-node-modules-dev:

--- a/scripts/init-admin.sh
+++ b/scripts/init-admin.sh
@@ -5,7 +5,7 @@ SUPERUSER_PASSWORD=${SUPERUSER_PASSWORD}
 
 ADMIN_EMAIL="${SUPERUSER_LOGIN}@example.com"
 ADMIN_PASSWORD=${SUPERUSER_PASSWORD}
-API_URL="http://localhost:3200"
+API_URL=${BIDON_ADMIN_URL:-"http://localhost:3200"}
 
 if [ -z "$SUPERUSER_LOGIN" ] || [ -z "$SUPERUSER_PASSWORD" ]; then
   echo "Error: SUPERUSER_LOGIN and SUPERUSER_PASSWORD environment variables are required but not set."
@@ -14,8 +14,9 @@ fi
 
 AUTH_HEADER=$(echo -n "$SUPERUSER_LOGIN:$SUPERUSER_PASSWORD" | base64)
 
-echo "Waiting for bidon-admin API to be ready..."
-while ! curl -s "$API_URL/health_checks" | grep 'OK' > /dev/null; do
+echo "Waiting for bidon-admin API ($API_URL) to be ready..."
+while ! $(curl -s "$API_URL/health_checks" | grep -i 'OK' > /dev/null); do
+  echo "Waiting for bidon-admin API ..."
   sleep 5
 done
 

--- a/web/bidon_ui/nuxt.config.ts
+++ b/web/bidon_ui/nuxt.config.ts
@@ -1,8 +1,8 @@
 // https://nuxt.com/docs/api/configuration/nuxt-config
-const apiProxyTarget = process.env.NUXT_API_PROXY_TARGET || "http://localhost:1323";
+const apiProxyTarget =
+  process.env.NUXT_API_PROXY_TARGET || "http://localhost:1323";
 
 export default defineNuxtConfig({
-
   alias: {
     assets: "/<rootDir>/assets",
   },

--- a/web/bidon_ui/nuxt.config.ts
+++ b/web/bidon_ui/nuxt.config.ts
@@ -1,5 +1,8 @@
 // https://nuxt.com/docs/api/configuration/nuxt-config
+const apiProxyTarget = process.env.NUXT_API_PROXY_TARGET || "http://localhost:1323";
+
 export default defineNuxtConfig({
+
   alias: {
     assets: "/<rootDir>/assets",
   },
@@ -32,8 +35,8 @@ export default defineNuxtConfig({
   },
 
   routeRules: {
-    "/auth/**": { proxy: "http://localhost:1323/auth/**" },
-    "/api/**": { proxy: "http://localhost:1323/api/**" },
+    "/auth/**": { proxy: `${apiProxyTarget}/auth/**` },
+    "/api/**": { proxy: `${apiProxyTarget}/api/**` },
   },
 
   compatibilityDate: "2024-10-31",


### PR DESCRIPTION
Added docker-compose.dev.yml for a local development setup using docker compose. This can be used to build, run and test the bidon backend with the `bidon-admin` and `bidon-sdkapi` and all the dependent services.