### PR TITLE
Feature/BAC-5/UI improvement - App overview page with inline auction config, line item, and demand p…

### DIFF
--- a/web/bidon_ui/CLAUDE.md
+++ b/web/bidon_ui/CLAUDE.md
@@ -5,7 +5,6 @@ This file provides context and guidelines for working with the Bidon admin web U
 ## Overview
 
 **bidon_ui** is a Nuxt 3 SPA (Single Page Application) — the admin dashboard for the Bidon ad mediation platform. It provides CRUD management for:
-
 - Apps, Demand Sources, Demand Source Accounts
 - Line Items, App Demand Profiles
 - Auction Configurations (v2)
@@ -103,7 +102,6 @@ Every resource follows the same four-page pattern:
 **Prefer `$apiFetch` (ofetch) over `ApiService` (Axios).** Axios is being phased out.
 
 Both clients:
-
 - Base URL: `/api`
 - Header: `X-Bidon-App: web`
 - Auto-convert request body to `snake_case`
@@ -226,7 +224,6 @@ Use `ResourceCard` for show pages. Field definitions from `constants/ResourceCar
 ## Data Transformation
 
 All snake_case ↔ camelCase conversion is automatic:
-
 - Request: `{ adType: "banner" }` → `{ ad_type: "banner" }`
 - Response: `{ ad_type: "banner" }` → `{ adType: "banner" }`
 - Fields starting with `_` are preserved (e.g. `_permissions`)

--- a/web/bidon_ui/components/app_demand_profiles/InlineDemandProfileForm.vue
+++ b/web/bidon_ui/components/app_demand_profiles/InlineDemandProfileForm.vue
@@ -1,0 +1,275 @@
+<template>
+  <div class="border-t border-blue-100 bg-blue-50 px-4 py-3">
+    <p class="text-xs font-semibold text-blue-700 uppercase tracking-wide mb-3">
+      {{ isEditMode ? "Edit" : "New" }} Demand Profile
+      <span v-if="activeNetworkLabel"> — {{ activeNetworkLabel }}</span>
+    </p>
+
+    <div
+      class="border border-blue-200 rounded-lg bg-white overflow-hidden divide-y divide-gray-100 mb-3"
+    >
+      <!-- Network selector (only when networkKey not pre-set and not editing) -->
+      <FormField
+        v-if="!props.networkKey && !isEditMode"
+        label="Network"
+        required
+      >
+        <Dropdown
+          v-model="selectedNetworkKey"
+          :options="networkOptions"
+          option-label="label"
+          option-value="key"
+          placeholder="Select network…"
+          class="w-full"
+          filter
+        />
+      </FormField>
+
+      <template v-if="activeNetworkKey">
+        <div v-if="accountsLoading" class="px-4 py-3 text-xs text-gray-400">
+          Loading accounts…
+        </div>
+        <div
+          v-else-if="!accounts.length"
+          class="px-4 py-3 text-xs text-red-500"
+        >
+          No demand source accounts found for {{ activeNetworkLabel }}.
+          <NuxtLink
+            to="/demand_source_accounts"
+            class="underline hover:text-red-700"
+          >
+            Set one up here.
+          </NuxtLink>
+        </div>
+
+        <template v-else>
+          <FormField label="Account" :required="accounts.length > 1">
+            <template v-if="accounts.length > 1">
+              <Dropdown
+                v-model="accountId"
+                :options="accounts"
+                option-label="label"
+                option-value="id"
+                placeholder="Select account…"
+                class="w-full"
+              />
+              <small
+                v-if="errors.accountId"
+                class="text-red-500 text-xs mt-1 block"
+              >
+                {{ errors.accountId }}
+              </small>
+            </template>
+            <span v-else class="text-sm text-gray-700">
+              {{ accounts[0].label }}
+            </span>
+          </FormField>
+
+          <AppDemandProfileDataFormFields
+            v-model:schema="dataSchema"
+            v-model:data="data"
+            :account-type="activeAccountType"
+          />
+
+          <FormField label="Enabled">
+            <Checkbox v-model="enabled" :binary="true" />
+          </FormField>
+        </template>
+      </template>
+    </div>
+
+    <p v-if="submitError" class="text-xs text-red-500 mb-2">
+      {{ submitError }}
+    </p>
+
+    <div class="flex justify-end gap-2">
+      <button type="button" class="btn-cancel btn-sm" @click="$emit('cancel')">
+        <i class="pi pi-times" /> Cancel
+      </button>
+      <Button
+        v-if="activeNetworkKey && accounts.length"
+        type="button"
+        :label="isEditMode ? 'Update' : 'Save'"
+        icon="pi pi-check"
+        size="small"
+        :loading="saving"
+        @click="save"
+      />
+    </div>
+  </div>
+</template>
+
+<script setup>
+import * as yup from "yup";
+import {
+  NETWORK_DEFS,
+  NETWORK_ACCOUNT_TYPE_BY_KEY,
+  NETWORK_LABEL_BY_KEY,
+} from "@/constants/Networks.js";
+
+const props = defineProps({
+  appId: { type: [Number, String], required: true },
+  networkKey: { type: String, default: null },
+  initialProfile: { type: Object, default: null },
+});
+
+const emit = defineEmits(["created", "updated", "cancel"]);
+
+const isEditMode = computed(() => !!props.initialProfile);
+
+// When networkKey is pre-set (edit or contextual create), use it directly.
+// Otherwise let the user pick via dropdown.
+const selectedNetworkKey = ref(props.networkKey ?? null);
+const activeNetworkKey = computed(
+  () => props.networkKey ?? selectedNetworkKey.value,
+);
+
+const activeNetworkLabel = computed(() =>
+  activeNetworkKey.value
+    ? (NETWORK_LABEL_BY_KEY[activeNetworkKey.value] ?? activeNetworkKey.value)
+    : null,
+);
+const activeAccountType = computed(() =>
+  activeNetworkKey.value
+    ? (NETWORK_ACCOUNT_TYPE_BY_KEY[activeNetworkKey.value] ??
+      activeNetworkKey.value)
+    : null,
+);
+
+const networkOptions = NETWORK_DEFS.map((n) => ({
+  key: n.key,
+  label: n.label,
+}));
+
+const dataSchema = ref(yup.object());
+
+const { errors, useFieldModel, handleSubmit } = useForm({
+  validationSchema: computed(() =>
+    yup.object({
+      accountId: yup.number().required().label("Account"),
+      data: dataSchema.value,
+      enabled: yup.boolean(),
+    }),
+  ),
+  initialValues: {
+    accountId: props.initialProfile?.accountId ?? null,
+    data: props.initialProfile?.data ?? {},
+    enabled: props.initialProfile?.enabled ?? true,
+  },
+});
+
+const accountId = useFieldModel("accountId");
+const data = useFieldModel("data");
+const enabled = useFieldModel("enabled");
+
+const accountsLoading = ref(false);
+const accounts = ref([]);
+const allAccounts = ref([]);
+
+onMounted(async () => {
+  accountsLoading.value = true;
+  try {
+    const result = await $apiFetch("/demand_source_accounts", {
+      params: { limit: 1000 },
+    });
+    allAccounts.value = (
+      Array.isArray(result) ? result : (result.items ?? [])
+    ).map((a) => ({
+      id: a.id,
+      type: a.type,
+      label: a.label ? `${a.label} (#${a.id})` : `#${a.id}`,
+      demandSourceId: a.demandSourceId,
+    }));
+  } finally {
+    accountsLoading.value = false;
+  }
+  loadAccountsForNetwork();
+});
+
+function loadAccountsForNetwork() {
+  if (!activeNetworkKey.value) {
+    accounts.value = [];
+    return;
+  }
+  if (isEditMode.value && props.initialProfile?.demandSourceId) {
+    // Edit mode: match by demandSourceId — more reliable than type string comparison
+    accounts.value = allAccounts.value.filter(
+      (a) => a.demandSourceId === props.initialProfile.demandSourceId,
+    );
+  } else if (activeAccountType.value) {
+    // Create mode: case-insensitive type match for robustness
+    const target = activeAccountType.value.toLowerCase();
+    accounts.value = allAccounts.value.filter(
+      (a) => a.type?.toLowerCase() === target,
+    );
+  } else {
+    accounts.value = [];
+    return;
+  }
+  if (accounts.value.length === 1) {
+    accountId.value = accounts.value[0].id;
+  } else if (isEditMode.value && props.initialProfile?.accountId) {
+    accountId.value = props.initialProfile.accountId;
+  } else {
+    accountId.value = null;
+  }
+}
+
+watch(activeNetworkKey, () => {
+  loadAccountsForNetwork();
+});
+
+const demandSourceId = computed(
+  () =>
+    allAccounts.value.find((a) => a.id === accountId.value)?.demandSourceId ??
+    null,
+);
+
+const saving = ref(false);
+const submitError = ref("");
+
+const save = handleSubmit(async (values) => {
+  saving.value = true;
+  submitError.value = "";
+  try {
+    if (isEditMode.value) {
+      const result = await $apiFetch(
+        `/app_demand_profiles/${props.initialProfile.id}`,
+        {
+          method: "PATCH",
+          body: {
+            accountId: values.accountId,
+            demandSourceId: demandSourceId.value,
+            accountType: activeAccountType.value,
+            data: values.data ?? {},
+            enabled: values.enabled,
+          },
+        },
+      );
+      emit("updated", result);
+    } else {
+      const result = await $apiFetch("/app_demand_profiles", {
+        method: "POST",
+        body: {
+          appId: Number(props.appId),
+          accountId: values.accountId,
+          demandSourceId: demandSourceId.value,
+          accountType: activeAccountType.value,
+          data: values.data ?? {},
+          enabled: values.enabled,
+        },
+      });
+      emit("created", result);
+    }
+  } catch (err) {
+    const msg = err.data?.error?.message;
+    submitError.value =
+      msg ||
+      (isEditMode.value
+        ? "Failed to update demand profile"
+        : "Failed to create demand profile");
+  } finally {
+    saving.value = false;
+  }
+});
+</script>

--- a/web/bidon_ui/components/apps/AppAuctionConfigurationsSection.vue
+++ b/web/bidon_ui/components/apps/AppAuctionConfigurationsSection.vue
@@ -1,0 +1,415 @@
+<template>
+  <div class="mt-10 mb-10">
+    <div class="flex items-center justify-between mb-4">
+      <div>
+        <h3 class="text-base font-semibold text-gray-700">
+          Auction Configurations
+        </h3>
+        <p class="text-sm text-gray-400 mt-0.5">
+          Per ad-type auction settings with CPM and bidding networks.
+        </p>
+      </div>
+      <button
+        :class="['btn-sm', showInlineConfigForm ? 'btn-cancel' : 'btn-new']"
+        @click="toggleConfigForm"
+      >
+        <i
+          :class="['pi', showInlineConfigForm ? 'pi-times' : 'pi-plus']"
+          aria-hidden="true"
+        />
+        {{ showInlineConfigForm ? "Cancel" : "New Auction Config" }}
+      </button>
+    </div>
+
+    <InlineAuctionConfigForm
+      v-if="showInlineConfigForm"
+      :app-id="appId"
+      :clone-from="cloneSourceConfig"
+      @created="handleAuctionConfigCreated"
+      @cancel="showInlineConfigForm = false"
+    />
+
+    <!-- Filters -->
+    <div
+      v-if="auctionConfigs.length"
+      class="flex flex-wrap items-center gap-3 mb-4"
+    >
+      <div class="relative">
+        <svg
+          class="absolute left-2.5 top-1/2 -translate-y-1/2 w-3.5 h-3.5 text-gray-400 pointer-events-none"
+          fill="none"
+          viewBox="0 0 24 24"
+          stroke="currentColor"
+          stroke-width="2"
+          aria-hidden="true"
+        >
+          <path
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            d="M21 21l-4.35-4.35M17 11A6 6 0 1 1 5 11a6 6 0 0 1 12 0z"
+          />
+        </svg>
+        <label for="auction-config-search" class="sr-only">
+          Search configurations by name
+        </label>
+        <input
+          id="auction-config-search"
+          v-model="configSearch"
+          type="text"
+          placeholder="Search by name…"
+          class="pl-8 pr-3 py-1.5 text-sm border border-gray-200 rounded-lg bg-white focus:outline-none focus:ring-2 focus:ring-blue-300 w-52"
+        />
+      </div>
+      <div class="flex flex-wrap gap-1.5">
+        <button
+          :class="[
+            'text-xs px-3 py-1 rounded-md border font-medium transition-colors',
+            configAdTypeFilter === null
+              ? 'bg-violet-600 border-violet-600 text-white'
+              : 'bg-white border-gray-200 text-gray-600 hover:border-violet-300 hover:text-violet-700',
+          ]"
+          @click="configAdTypeFilter = null"
+        >
+          All
+        </button>
+        <button
+          v-for="adTypeOption in configAdTypes"
+          :key="adTypeOption"
+          :class="[
+            'text-xs px-3 py-1 rounded-md border font-medium capitalize transition-colors',
+            configAdTypeFilter === adTypeOption
+              ? 'bg-violet-600 border-violet-600 text-white'
+              : 'bg-white border-gray-200 text-gray-600 hover:border-violet-300 hover:text-violet-700',
+          ]"
+          @click="configAdTypeFilter = adTypeOption"
+        >
+          {{ adTypeOption }}
+        </button>
+      </div>
+    </div>
+
+    <p v-if="!auctionConfigs.length" class="text-sm text-gray-400 py-4">
+      No auction configurations for this app yet.
+    </p>
+    <p
+      v-else-if="!filteredConfigGroups.length"
+      class="text-sm text-gray-400 py-4"
+    >
+      No configurations match the current filters.
+    </p>
+
+    <div v-for="group in filteredConfigGroups" :key="group.adType" class="mb-6">
+      <div class="flex items-center gap-2 mb-3">
+        <span class="badge badge-ad-type">{{ group.adType }}</span>
+        <span class="text-sm text-gray-400">
+          {{ group.items.length }} config{{
+            group.items.length !== 1 ? "s" : ""
+          }}
+        </span>
+      </div>
+
+      <div class="grid grid-cols-1 gap-4">
+        <div
+          v-for="config in group.items"
+          :key="config.id"
+          class="border border-gray-200 rounded-lg bg-white overflow-hidden flex flex-col"
+        >
+          <div
+            class="card-header cursor-pointer select-none"
+            @click="toggleCollapse(config.id)"
+          >
+            <div class="flex flex-col gap-1 min-w-0">
+              <div class="flex items-center gap-2 flex-wrap">
+                <span class="font-semibold text-gray-800">
+                  {{ config.name }}
+                </span>
+                <span class="badge badge-ad-type">{{ config.adType }}</span>
+                <span class="badge badge-segment">
+                  {{
+                    config.isDefault
+                      ? "Default"
+                      : (config.segment?.name ?? "Segment")
+                  }}
+                </span>
+              </div>
+              <div class="flex items-center gap-3 flex-wrap">
+                <span
+                  class="flex items-center gap-1 text-xs text-gray-400 font-mono"
+                >
+                  <span class="text-gray-300">floor</span>
+                  ${{ config.pricefloor }}
+                </span>
+                <span
+                  class="flex items-center gap-1 text-xs text-gray-400 font-mono"
+                >
+                  <span class="text-gray-300">timeout</span>
+                  {{ config.timeout }}ms
+                </span>
+                <span
+                  v-if="config.auctionKey"
+                  class="flex items-center gap-1 text-xs text-gray-400 font-mono"
+                >
+                  <span class="text-gray-300">key</span>
+                  {{ config.auctionKey }}
+                  <button
+                    :aria-label="`Copy auction key ${config.auctionKey}`"
+                    class="text-gray-300 hover:text-blue-400 transition-colors"
+                    @click.stop="copyField(config.auctionKey)"
+                  >
+                    <i class="pi pi-copy" aria-hidden="true" />
+                  </button>
+                </span>
+                <span
+                  v-if="config.publicUid"
+                  class="flex items-center gap-1 text-xs text-gray-400 font-mono"
+                >
+                  <span class="text-gray-300">uid</span>
+                  {{ config.publicUid }}
+                  <button
+                    :aria-label="`Copy public UID ${config.publicUid}`"
+                    class="text-gray-300 hover:text-blue-400 transition-colors"
+                    @click.stop="copyField(config.publicUid)"
+                  >
+                    <i class="pi pi-copy" aria-hidden="true" />
+                  </button>
+                </span>
+              </div>
+            </div>
+            <div class="flex items-center gap-2 shrink-0">
+              <div class="flex gap-2" @click.stop>
+                <button
+                  class="btn-new btn-sm"
+                  @click="cloneAuctionConfig(config)"
+                >
+                  <i class="pi pi-clone" /> Clone
+                </button>
+                <button
+                  :class="[
+                    'btn-sm',
+                    editingConfigId === config.id ? 'btn-cancel' : 'btn-edit',
+                  ]"
+                  @click="
+                    editingConfigId =
+                      editingConfigId === config.id ? null : config.id
+                  "
+                >
+                  <i
+                    :class="[
+                      'pi',
+                      editingConfigId === config.id ? 'pi-times' : 'pi-pencil',
+                    ]"
+                    aria-hidden="true"
+                  />
+                  {{ editingConfigId === config.id ? "Cancel" : "Edit" }}
+                </button>
+              </div>
+              <i
+                class="pi pi-chevron-down text-gray-400 transition-transform duration-300"
+                :style="
+                  collapsedConfigIds.has(config.id)
+                    ? 'transform: rotate(-90deg)'
+                    : ''
+                "
+                aria-hidden="true"
+              />
+            </div>
+          </div>
+
+          <Transition name="collapse">
+            <div v-if="!collapsedConfigIds.has(config.id)" class="flex-1">
+              <InlineAuctionConfigForm
+                v-if="editingConfigId === config.id"
+                :app-id="appId"
+                :edit-config="config"
+                class="!mb-0 !border-0 !rounded-none"
+                @updated="handleAuctionConfigUpdated"
+                @cancel="editingConfigId = null"
+              />
+              <div v-else class="divide-y divide-gray-100">
+                <AuctionConfigNetworkSection
+                  :config="config"
+                  :is-bidding="true"
+                  :all-line-items="allLineItems"
+                  :show-inline-form="showInlineForm"
+                  :app-id="appId"
+                  @toggle-inline-form="toggleInlineForm"
+                  @line-item-created="handleLineItemCreated"
+                  @line-item-updated="handleLineItemUpdated"
+                  @inline-form-cancel="showInlineForm = null"
+                />
+                <AuctionConfigNetworkSection
+                  :config="config"
+                  :is-bidding="false"
+                  :all-line-items="allLineItems"
+                  :show-inline-form="showInlineForm"
+                  :app-id="appId"
+                  @toggle-inline-form="toggleInlineForm"
+                  @line-item-created="handleLineItemCreated"
+                  @line-item-updated="handleLineItemUpdated"
+                  @inline-form-cancel="showInlineForm = null"
+                />
+              </div>
+            </div>
+          </Transition>
+        </div>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup>
+import { useToast } from "primevue/usetoast";
+
+const props = defineProps({
+  initialAuctionConfigs: { type: Array, required: true },
+  initialLineItems: { type: Array, required: true },
+  appId: { type: [Number, String], required: true },
+});
+
+const toast = useToast();
+const auctionConfigs = ref([...props.initialAuctionConfigs]);
+const allLineItems = ref([...props.initialLineItems]);
+
+const configSearch = ref("");
+const configAdTypeFilter = ref(null);
+
+const configAdTypes = computed(() =>
+  [...new Set(auctionConfigs.value.map((c) => c.adType))].sort(),
+);
+
+const filteredConfigs = computed(() => {
+  const search = configSearch.value.trim().toLowerCase();
+  return auctionConfigs.value.filter((c) => {
+    if (configAdTypeFilter.value && c.adType !== configAdTypeFilter.value)
+      return false;
+    if (search && !c.name?.toLowerCase().includes(search)) return false;
+    return true;
+  });
+});
+
+const filteredConfigGroups = computed(() => {
+  const byAdType = {};
+  for (const config of filteredConfigs.value) {
+    if (!byAdType[config.adType]) byAdType[config.adType] = [];
+    byAdType[config.adType].push(config);
+  }
+  return Object.entries(byAdType)
+    .sort(([a], [b]) => a.localeCompare(b))
+    .map(([adType, items]) => ({ adType, items }));
+});
+
+function copyField(value) {
+  navigator.clipboard.writeText(String(value));
+}
+
+const showInlineConfigForm = ref(false);
+const cloneSourceConfig = ref(null);
+const editingConfigId = ref(null);
+const collapsedConfigIds = ref(new Set());
+
+function toggleCollapse(configId) {
+  const next = new Set(collapsedConfigIds.value);
+  if (next.has(configId)) {
+    next.delete(configId);
+  } else {
+    next.add(configId);
+  }
+  collapsedConfigIds.value = next;
+}
+
+function toggleConfigForm() {
+  showInlineConfigForm.value = !showInlineConfigForm.value;
+  cloneSourceConfig.value = null;
+  editingConfigId.value = null;
+}
+
+function cloneAuctionConfig(config) {
+  cloneSourceConfig.value = config;
+  showInlineConfigForm.value = true;
+  editingConfigId.value = null;
+  nextTick(() => {
+    document
+      .querySelector(".inline-auction-config-form")
+      ?.scrollIntoView({ behavior: "smooth", block: "start" });
+  });
+}
+
+function handleAuctionConfigCreated(newConfig) {
+  auctionConfigs.value.push(newConfig);
+  showInlineConfigForm.value = false;
+  cloneSourceConfig.value = null;
+}
+
+function handleAuctionConfigUpdated(updatedConfig) {
+  const idx = auctionConfigs.value.findIndex((c) => c.id === updatedConfig.id);
+  if (idx !== -1) {
+    auctionConfigs.value[idx] = updatedConfig;
+  }
+  editingConfigId.value = null;
+}
+
+const showInlineForm = ref(null);
+
+function inlineFormKey(configId, networkKey, isBidding) {
+  return `${configId}-${networkKey}-${isBidding ? "b" : "w"}`;
+}
+
+function toggleInlineForm(configId, networkKey, isBidding) {
+  const key = inlineFormKey(configId, networkKey, isBidding);
+  showInlineForm.value = showInlineForm.value === key ? null : key;
+}
+
+async function handleLineItemCreated(newItem, configId) {
+  allLineItems.value.push(newItem);
+
+  const configIdx = auctionConfigs.value.findIndex((c) => c.id === configId);
+  if (configIdx === -1) return;
+
+  const config = auctionConfigs.value[configIdx];
+  const updatedAdUnitIds = [...(config.adUnitIds ?? []), Number(newItem.id)];
+
+  try {
+    const data = await $apiFetch(`/v2/auction_configurations/${configId}`, {
+      method: "PATCH",
+      body: { adUnitIds: updatedAdUnitIds },
+    });
+    auctionConfigs.value[configIdx] = data;
+  } catch (err) {
+    toast.add({
+      severity: "error",
+      summary: "Link failed",
+      detail:
+        err.data?.error?.message ??
+        "Line item was created but could not be linked to the auction configuration. Please edit the configuration manually.",
+    });
+    auctionConfigs.value[configIdx] = {
+      ...config,
+      adUnitIds: updatedAdUnitIds,
+    };
+  }
+
+  showInlineForm.value = null;
+}
+
+function handleLineItemUpdated(updatedItem) {
+  const idx = allLineItems.value.findIndex((i) => i.id === updatedItem.id);
+  if (idx !== -1) {
+    allLineItems.value[idx] = updatedItem;
+  }
+}
+</script>
+
+<style scoped>
+.collapse-enter-active,
+.collapse-leave-active {
+  transition: max-height 0.3s ease, opacity 0.25s ease;
+  overflow: hidden;
+  max-height: 2000px;
+}
+
+.collapse-enter-from,
+.collapse-leave-to {
+  max-height: 0;
+  opacity: 0;
+}
+</style>

--- a/web/bidon_ui/components/apps/AppAuctionConfigurationsSection.vue
+++ b/web/bidon_ui/components/apps/AppAuctionConfigurationsSection.vue
@@ -188,10 +188,7 @@
                     'btn-sm',
                     editingConfigId === config.id ? 'btn-cancel' : 'btn-edit',
                   ]"
-                  @click="
-                    editingConfigId =
-                      editingConfigId === config.id ? null : config.id
-                  "
+                  @click="toggleEditingAuctionConfig(config.id)"
                 >
                   <i
                     :class="[
@@ -235,6 +232,7 @@
                   @toggle-inline-form="toggleInlineForm"
                   @line-item-created="handleLineItemCreated"
                   @line-item-updated="handleLineItemUpdated"
+                  @dismiss-inline-create="showInlineForm = null"
                   @inline-form-cancel="showInlineForm = null"
                 />
                 <AuctionConfigNetworkSection
@@ -246,6 +244,7 @@
                   @toggle-inline-form="toggleInlineForm"
                   @line-item-created="handleLineItemCreated"
                   @line-item-updated="handleLineItemUpdated"
+                  @dismiss-inline-create="showInlineForm = null"
                   @inline-form-cancel="showInlineForm = null"
                 />
               </div>
@@ -327,6 +326,7 @@ function cloneAuctionConfig(config) {
   cloneSourceConfig.value = config;
   showInlineConfigForm.value = true;
   editingConfigId.value = null;
+  showInlineForm.value = null;
   nextTick(() => {
     document
       .querySelector(".inline-auction-config-form")
@@ -346,6 +346,16 @@ function handleAuctionConfigUpdated(updatedConfig) {
     auctionConfigs.value[idx] = updatedConfig;
   }
   editingConfigId.value = null;
+}
+
+function toggleEditingAuctionConfig(configId) {
+  const next = editingConfigId.value === configId ? null : configId;
+  editingConfigId.value = next;
+  if (next !== null) {
+    showInlineConfigForm.value = false;
+    cloneSourceConfig.value = null;
+    showInlineForm.value = null;
+  }
 }
 
 const showInlineForm = ref(null);
@@ -382,10 +392,6 @@ async function handleLineItemCreated(newItem, configId) {
         err.data?.error?.message ??
         "Line item was created but could not be linked to the auction configuration. Please edit the configuration manually.",
     });
-    auctionConfigs.value[configIdx] = {
-      ...config,
-      adUnitIds: updatedAdUnitIds,
-    };
   }
 
   showInlineForm.value = null;
@@ -402,7 +408,9 @@ function handleLineItemUpdated(updatedItem) {
 <style scoped>
 .collapse-enter-active,
 .collapse-leave-active {
-  transition: max-height 0.3s ease, opacity 0.25s ease;
+  transition:
+    max-height 0.3s ease,
+    opacity 0.25s ease;
   overflow: hidden;
   max-height: 2000px;
 }

--- a/web/bidon_ui/components/apps/AppDemandProfilesSection.vue
+++ b/web/bidon_ui/components/apps/AppDemandProfilesSection.vue
@@ -1,0 +1,203 @@
+<template>
+  <div class="mt-10">
+    <div class="flex items-center justify-between mb-4">
+      <div>
+        <h3 class="text-base font-semibold text-gray-700">
+          Demand Source Profiles
+        </h3>
+        <p class="text-sm text-gray-400 mt-0.5">
+          App-level configuration for each connected demand source.
+        </p>
+      </div>
+      <button
+        :class="['btn-sm', showCreateForm ? 'btn-cancel' : 'btn-new']"
+        @click="showCreateForm = !showCreateForm"
+      >
+        <i :class="['pi', showCreateForm ? 'pi-times' : 'pi-plus']" />
+        {{ showCreateForm ? "Cancel" : "Create Profile" }}
+      </button>
+    </div>
+
+    <InlineDemandProfileForm
+      v-if="showCreateForm"
+      :app-id="appId"
+      class="mb-4 rounded-lg overflow-hidden border border-blue-100"
+      @created="onProfileCreated"
+      @cancel="showCreateForm = false"
+    />
+
+    <!-- Configured profiles — iterated directly from profiles, not filtered through NETWORK_DEFS -->
+    <div
+      v-if="profiles.length"
+      class="grid grid-cols-1 gap-3 md:grid-cols-2 mb-6"
+    >
+      <div
+        v-for="profile in profiles"
+        :key="profile.id"
+        :class="[
+          'border border-gray-200 rounded-lg bg-white overflow-hidden',
+          !profile.enabled && 'opacity-60',
+        ]"
+      >
+        <div class="card-header">
+          <div class="flex items-center gap-2 flex-wrap min-w-0">
+            <span class="font-semibold text-gray-800">
+              {{ profileLabel(profile) }}
+            </span>
+            <span
+              :class="
+                profile.enabled ? 'badge badge-active' : 'badge badge-disabled'
+              "
+            >
+              <span
+                :class="[
+                  'w-1.5 h-1.5 rounded-full',
+                  profile.enabled ? 'bg-green-500' : 'bg-red-400',
+                ]"
+              />
+              {{ profile.enabled ? "Active" : "Disabled" }}
+            </span>
+          </div>
+          <div class="flex gap-2 shrink-0">
+            <button
+              :class="[
+                'btn-sm',
+                editingId === profile.id ? 'btn-cancel' : 'btn-edit',
+              ]"
+              @click="toggleEdit(profile.id)"
+            >
+              <i
+                :class="[
+                  'pi',
+                  editingId === profile.id ? 'pi-times' : 'pi-pencil',
+                ]"
+              />
+              {{ editingId === profile.id ? "Cancel" : "Edit" }}
+            </button>
+          </div>
+        </div>
+
+        <InlineDemandProfileForm
+          v-if="editingId === profile.id"
+          :app-id="appId"
+          :network-key="
+            accountTypeToNetworkKey(
+              profile.accountType ?? profile.account?.type,
+            )
+          "
+          :initial-profile="profile"
+          @updated="onProfileUpdated"
+          @cancel="editingId = null"
+        />
+
+        <div v-else class="divide-y divide-gray-100">
+          <div class="flex items-start gap-3 px-6 py-3">
+            <span class="text-xs text-gray-400 w-28 shrink-0 pt-px">
+              Account
+            </span>
+            <span class="text-sm text-gray-700">
+              {{ accountLabel(profile.account) }}
+            </span>
+          </div>
+          <div class="flex items-start gap-3 px-6 py-3">
+            <span class="text-xs text-gray-400 w-28 shrink-0 pt-px">
+              Demand Source
+            </span>
+            <NuxtLink
+              v-if="profile.demandSource"
+              :to="`/demand_sources/${profile.demandSource.id}`"
+              class="text-sm text-blue-600 hover:underline"
+            >
+              {{ profile.demandSource.humanName }}
+            </NuxtLink>
+            <span v-else class="text-sm text-gray-400">—</span>
+          </div>
+          <template v-if="profile.data && Object.keys(profile.data).length">
+            <div
+              v-for="(value, key) in profile.data"
+              :key="key"
+              class="flex items-start gap-3 px-6 py-3"
+            >
+              <span
+                class="text-xs text-gray-400 w-28 shrink-0 pt-px capitalize"
+              >
+                {{ key.replace(/_/g, " ") }}
+              </span>
+              <span class="text-sm text-gray-700 font-mono break-all">
+                {{ value }}
+              </span>
+            </div>
+          </template>
+          <div v-else class="flex items-start gap-3 px-6 py-3">
+            <span class="text-xs text-gray-400 w-28 shrink-0 pt-px"
+              >Config Data</span
+            >
+            <span class="text-sm text-gray-400">No adapter data</span>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <p v-if="!profiles.length" class="text-sm text-gray-400 py-4">
+      No demand sources configured for this app yet.
+    </p>
+  </div>
+</template>
+
+<script setup>
+import { NETWORK_DEFS } from "@/constants/Networks.js";
+
+const props = defineProps({
+  demandProfiles: { type: Array, required: true },
+  appId: { type: [Number, String], required: true },
+});
+
+const profiles = ref([...props.demandProfiles]);
+watch(
+  () => props.demandProfiles,
+  (val) => {
+    profiles.value = [...val];
+  },
+);
+const editingId = ref(null);
+const showCreateForm = ref(false);
+
+const accountTypeToNetworkKey = (accountType) =>
+  NETWORK_DEFS.find((n) => n.accountType === accountType)?.key ?? accountType;
+
+function profileLabel(profile) {
+  return (
+    profile.demandSource?.humanName ??
+    NETWORK_DEFS.find(
+      (n) => n.accountType === (profile.accountType ?? profile.account?.type),
+    )?.label ??
+    profile.accountType ??
+    profile.account?.type ??
+    "Unknown"
+  );
+}
+
+function accountLabel(account) {
+  if (!account) return "";
+  const type = account.type?.split("::")?.[1] ?? account.type;
+  return account.label
+    ? `${type} · ${account.label}`
+    : `${type} (#${account.id})`;
+}
+
+function toggleEdit(profileId) {
+  editingId.value = editingId.value === profileId ? null : profileId;
+  showCreateForm.value = false;
+}
+
+function onProfileUpdated(updated) {
+  const idx = profiles.value.findIndex((p) => p.id === updated.id);
+  if (idx !== -1) profiles.value[idx] = updated;
+  editingId.value = null;
+}
+
+function onProfileCreated(created) {
+  profiles.value.push(created);
+  showCreateForm.value = false;
+}
+</script>

--- a/web/bidon_ui/components/apps/AppDemandProfilesSection.vue
+++ b/web/bidon_ui/components/apps/AppDemandProfilesSection.vue
@@ -11,7 +11,10 @@
       </div>
       <button
         :class="['btn-sm', showCreateForm ? 'btn-cancel' : 'btn-new']"
-        @click="showCreateForm = !showCreateForm"
+        @click="
+          showCreateForm = !showCreateForm;
+          if (showCreateForm) editingId = null;
+        "
       >
         <i :class="['pi', showCreateForm ? 'pi-times' : 'pi-plus']" />
         {{ showCreateForm ? "Cancel" : "Create Profile" }}

--- a/web/bidon_ui/components/apps/AppOverviewCard.vue
+++ b/web/bidon_ui/components/apps/AppOverviewCard.vue
@@ -1,0 +1,85 @@
+<template>
+  <div class="card mb-8">
+    <div class="card-header">
+      <div class="flex items-center gap-2 flex-wrap">
+        <span class="font-semibold text-gray-800 text-lg">
+          {{ resource.humanName }}
+        </span>
+        <span class="badge badge-platform">{{ resource.platformId }}</span>
+        <span class="text-sm text-gray-400">{{ resource.packageName }}</span>
+      </div>
+      <div class="flex gap-2 shrink-0">
+        <NuxtLink
+          v-if="resource._permissions?.update"
+          :to="`/apps/${id}/edit`"
+          class="btn-edit btn-sm"
+        >
+          <i class="pi pi-pencil" /> Edit
+        </NuxtLink>
+        <DestroyButton
+          v-if="resource._permissions?.delete"
+          :id="id"
+          :path="resourcesPath"
+        />
+      </div>
+    </div>
+
+    <div class="divide-y divide-gray-100">
+      <div
+        v-for="field in OVERVIEW_FIELDS"
+        :key="field.key ?? field.label"
+        class="flex items-start gap-4 px-6 py-3"
+      >
+        <span class="text-sm text-gray-400 w-44 shrink-0 pt-px">
+          {{ field.label }}
+        </span>
+        <span
+          class="text-sm text-gray-700 font-mono break-all flex items-center gap-1.5 min-w-0"
+        >
+          {{ field.value ? field.value(resource) : resource[field.key] }}
+          <button
+            v-if="
+              field.copyable &&
+              (field.value ? field.value(resource) : resource[field.key])
+            "
+            :aria-label="`Copy ${field.label}`"
+            class="text-gray-300 hover:text-blue-400 transition-colors shrink-0"
+            @click="
+              copyField(
+                field.value ? field.value(resource) : resource[field.key],
+              )
+            "
+          >
+            <i class="pi pi-copy" aria-hidden="true" />
+          </button>
+        </span>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup>
+defineProps({
+  resource: { type: Object, required: true },
+  id: { type: [Number, String], required: true },
+  resourcesPath: { type: String, required: true },
+});
+
+const OVERVIEW_FIELDS = [
+  { label: "Package Name", key: "packageName", copyable: true },
+  { label: "Platform", key: "platformId" },
+  { label: "Owner", value: (r) => r.user?.email },
+  { label: "Public UID", key: "publicUid", copyable: true },
+  { label: "App Key", key: "appKey", copyable: true },
+  { label: "Store ID", key: "storeId" },
+  { label: "Store URL", key: "storeUrl" },
+  { label: "Categories", value: (r) => r.categories?.join(", ") },
+  { label: "Blocked Advertiser Domains", key: "badv" },
+  { label: "Blocked Categories", key: "bcat" },
+  { label: "Blocked Apps", key: "bapp" },
+];
+
+function copyField(value) {
+  navigator.clipboard.writeText(String(value));
+}
+</script>

--- a/web/bidon_ui/components/auction_configurations/AuctionConfigNetworkSection.vue
+++ b/web/bidon_ui/components/auction_configurations/AuctionConfigNetworkSection.vue
@@ -128,6 +128,7 @@ const emit = defineEmits([
   "lineItemCreated",
   "lineItemUpdated",
   "inlineFormCancel",
+  "dismissInlineCreate",
 ]);
 
 const editingItemId = ref(null);
@@ -144,7 +145,11 @@ function inlineFormKey(configId, networkKey, isBidding) {
 }
 
 function toggleEditForm(itemId) {
-  editingItemId.value = editingItemId.value === itemId ? null : itemId;
+  const next = editingItemId.value === itemId ? null : itemId;
+  if (next !== null) {
+    emit("dismissInlineCreate");
+  }
+  editingItemId.value = next;
 }
 
 function onItemUpdated(updatedItem) {

--- a/web/bidon_ui/components/auction_configurations/AuctionConfigNetworkSection.vue
+++ b/web/bidon_ui/components/auction_configurations/AuctionConfigNetworkSection.vue
@@ -1,0 +1,175 @@
+<template>
+  <div class="px-6 py-4">
+    <p class="text-sm font-semibold text-gray-400 uppercase tracking-wide mb-2">
+      {{ isBidding ? "Bidding Networks" : "Waterfall Networks" }}
+    </p>
+    <div v-if="groups.length" class="flex flex-col gap-2">
+      <details
+        v-for="group in groups"
+        :key="group.key"
+        open
+        class="group border border-gray-100 rounded-lg overflow-hidden"
+      >
+        <summary
+          class="flex items-center justify-between px-3 py-2 bg-gray-50 cursor-pointer list-none select-none hover:bg-gray-100 transition-colors"
+        >
+          <div class="flex items-center gap-2">
+            <svg
+              class="w-3.5 h-3.5 text-gray-400 transition-transform group-open:rotate-90"
+              fill="none"
+              viewBox="0 0 24 24"
+              stroke="currentColor"
+              stroke-width="2"
+              aria-hidden="true"
+            >
+              <path
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                d="M9 5l7 7-7 7"
+              />
+            </svg>
+            <span class="text-sm font-medium text-gray-700">{{
+              group.label
+            }}</span>
+            <span
+              :class="[
+                'badge',
+                isBidding ? 'badge-count-rtb' : 'badge-count-cpm',
+              ]"
+            >
+              {{ group.items.length }}
+            </span>
+          </div>
+          <button
+            class="btn-new btn-sm"
+            @click.stop="
+              $emit('toggleInlineForm', config.id, group.key, isBidding)
+            "
+          >
+            <i class="pi pi-plus" /> New Line Item
+          </button>
+        </summary>
+        <div class="divide-y divide-gray-50 bg-white">
+          <template v-for="item in group.items" :key="item.id">
+            <div class="flex items-center gap-3 px-4 py-2 text-sm">
+              <span class="flex-1 text-gray-700 truncate">
+                {{ item.humanName }}
+              </span>
+              <span v-if="!isBidding" class="text-sm text-gray-400 shrink-0">
+                ${{ item.bidFloor }}
+              </span>
+              <button
+                :class="[
+                  'btn-sm shrink-0',
+                  editingItemId === item.id ? 'btn-cancel' : 'btn-edit',
+                ]"
+                @click.stop="toggleEditForm(item.id)"
+              >
+                <i
+                  :class="[
+                    'pi',
+                    editingItemId === item.id ? 'pi-times' : 'pi-pencil',
+                  ]"
+                />
+                {{ editingItemId === item.id ? "Cancel" : "Edit" }}
+              </button>
+            </div>
+            <InlineLineItemForm
+              v-if="editingItemId === item.id"
+              :app-id="appId"
+              :ad-type="config.adType"
+              :network-key="group.key"
+              :is-bidding="isBidding"
+              :initial-item="item"
+              @updated="(updatedItem) => onItemUpdated(updatedItem)"
+              @cancel="editingItemId = null"
+            />
+          </template>
+          <div
+            v-if="
+              !group.items.length &&
+              showInlineForm !== inlineFormKey(config.id, group.key, isBidding)
+            "
+            class="px-4 py-2 text-sm text-gray-400"
+          >
+            No line items linked yet.
+          </div>
+          <InlineLineItemForm
+            v-if="
+              showInlineForm === inlineFormKey(config.id, group.key, isBidding)
+            "
+            :app-id="appId"
+            :ad-type="config.adType"
+            :network-key="group.key"
+            :is-bidding="isBidding"
+            @created="(item) => $emit('lineItemCreated', item, config.id)"
+            @cancel="$emit('inlineFormCancel')"
+          />
+        </div>
+      </details>
+    </div>
+    <p v-else class="text-sm text-gray-400">None configured</p>
+  </div>
+</template>
+
+<script setup>
+import { NETWORK_LABEL_BY_KEY } from "@/constants/Networks.js";
+
+const props = defineProps({
+  config: { type: Object, required: true },
+  isBidding: { type: Boolean, required: true },
+  allLineItems: { type: Array, required: true },
+  showInlineForm: { type: String, default: null },
+  appId: { type: [Number, String], required: true },
+});
+
+const emit = defineEmits([
+  "toggleInlineForm",
+  "lineItemCreated",
+  "lineItemUpdated",
+  "inlineFormCancel",
+]);
+
+const editingItemId = ref(null);
+
+watch(
+  () => props.showInlineForm,
+  () => {
+    editingItemId.value = null;
+  },
+);
+
+function inlineFormKey(configId, networkKey, isBidding) {
+  return `${configId}-${networkKey}-${isBidding ? "b" : "w"}`;
+}
+
+function toggleEditForm(itemId) {
+  editingItemId.value = editingItemId.value === itemId ? null : itemId;
+}
+
+function onItemUpdated(updatedItem) {
+  editingItemId.value = null;
+  emit("lineItemUpdated", updatedItem);
+}
+
+const groups = computed(() => {
+  const enabledKeys = props.isBidding
+    ? (props.config.bidding ?? [])
+    : (props.config.demands ?? []);
+  if (!enabledKeys.length) return [];
+
+  const configIds = new Set(props.config.adUnitIds ?? []);
+  const items = props.allLineItems.filter(
+    (item) =>
+      configIds.has(Number(item.id)) && item.isBidding === props.isBidding,
+  );
+
+  return enabledKeys.map((key) => ({
+    key,
+    label: NETWORK_LABEL_BY_KEY[key] ?? key,
+    items: items.filter(
+      (item) => item.account?.type?.split("::")?.[1]?.toLowerCase() === key,
+    ),
+  }));
+});
+</script>

--- a/web/bidon_ui/components/auction_configurations/InlineAuctionConfigForm.vue
+++ b/web/bidon_ui/components/auction_configurations/InlineAuctionConfigForm.vue
@@ -1,0 +1,137 @@
+<template>
+  <div
+    class="inline-auction-config-form border border-gray-200 rounded-lg bg-white overflow-hidden mb-4 [&_.card]:mb-0"
+  >
+    <AuctionConfigurationsForm
+      :key="formKey"
+      :value="initialValue"
+      :compact="isEditMode"
+      @submit="handleSubmit"
+    />
+
+    <p v-if="submitError" class="text-xs text-red-500 px-6 pb-3">
+      {{ submitError }}
+    </p>
+  </div>
+</template>
+
+<script setup>
+import { useToast } from "primevue/usetoast";
+
+const props = defineProps({
+  appId: { type: [Number, String], required: true },
+  cloneFrom: { type: Object, default: null },
+  editConfig: { type: Object, default: null },
+});
+
+const emit = defineEmits(["created", "updated", "cancel"]);
+
+const isEditMode = computed(() => !!props.editConfig);
+
+const formKey = computed(
+  () => props.editConfig?.id ?? props.cloneFrom?.id ?? "new",
+);
+
+const initialValue = computed(() => {
+  if (isEditMode.value) {
+    const {
+      id,
+      name,
+      appId,
+      adType,
+      pricefloor,
+      segmentId,
+      isDefault,
+      externalWinNotifications,
+      timeout,
+      demands,
+      bidding,
+      adUnitIds,
+      settings,
+    } = props.editConfig;
+    return {
+      id,
+      name,
+      appId: Number(appId),
+      adType,
+      pricefloor,
+      segmentId,
+      isDefault,
+      externalWinNotifications,
+      timeout,
+      demands,
+      bidding,
+      adUnitIds,
+      settings,
+    };
+  }
+
+  const base = { appId: Number(props.appId) };
+  if (!props.cloneFrom) return base;
+
+  const {
+    adType,
+    pricefloor,
+    segmentId,
+    externalWinNotifications,
+    timeout,
+    demands,
+    bidding,
+    adUnitIds,
+    settings,
+  } = props.cloneFrom;
+  return {
+    ...base,
+    adType,
+    pricefloor,
+    segmentId,
+    externalWinNotifications,
+    timeout,
+    demands,
+    bidding,
+    adUnitIds,
+    settings,
+    name: "",
+    isDefault: false,
+  };
+});
+
+const toast = useToast();
+const submitError = ref("");
+
+const handleSubmit = async (values) => {
+  submitError.value = "";
+  try {
+    if (isEditMode.value) {
+      const data = await $apiFetch(
+        `/v2/auction_configurations/${props.editConfig.id}`,
+        { method: "PATCH", body: values },
+      );
+      toast.add({
+        severity: "success",
+        summary: "Success",
+        detail: "Auction configuration updated!",
+        life: 3000,
+      });
+      emit("updated", data);
+    } else {
+      const data = await $apiFetch("/v2/auction_configurations", {
+        method: "POST",
+        body: values,
+      });
+      toast.add({
+        severity: "success",
+        summary: "Success",
+        detail: "Auction configuration created!",
+        life: 3000,
+      });
+      emit("created", data);
+    }
+  } catch (err) {
+    const msg = err.data?.error?.message;
+    submitError.value = isEditMode.value
+      ? msg || "Failed to update auction configuration"
+      : msg || "Failed to create auction configuration";
+  }
+};
+</script>

--- a/web/bidon_ui/components/auction_configurations/InlineLineItemForm.vue
+++ b/web/bidon_ui/components/auction_configurations/InlineLineItemForm.vue
@@ -1,0 +1,228 @@
+<template>
+  <div class="border-t border-blue-100 bg-blue-50 px-4 py-3">
+    <p class="text-xs font-semibold text-blue-700 uppercase tracking-wide mb-3">
+      {{ isEditMode ? "Edit" : "New" }} Line Item — {{ networkKey }}
+    </p>
+
+    <div v-if="accountsLoading" class="text-xs text-gray-400 mb-2">
+      Loading accounts…
+    </div>
+    <div v-else-if="!accounts.length" class="text-xs text-red-500 mb-2">
+      No demand source accounts found for {{ networkKey }}. Please create one
+      first.
+    </div>
+
+    <template v-else>
+      <div
+        class="border border-blue-200 rounded-lg bg-white overflow-hidden divide-y divide-gray-100 mb-3"
+      >
+        <!-- Account (read-only when single, dropdown when multiple) -->
+        <FormField label="Account" :required="accounts.length > 1">
+          <template v-if="accounts.length > 1">
+            <Dropdown
+              v-model="accountId"
+              :options="accounts"
+              option-label="label"
+              option-value="id"
+              placeholder="Select account…"
+              class="w-full"
+            >
+              <template #option="{ option }">
+                <span>{{ option.label || `#${option.id}` }}</span>
+              </template>
+            </Dropdown>
+            <small
+              v-if="errors.accountId"
+              class="text-red-500 text-xs mt-1 block"
+            >
+              {{ errors.accountId }}
+            </small>
+          </template>
+          <span v-else class="text-sm text-gray-700">
+            {{ accounts[0].label || `#${accounts[0].id}` }}
+          </span>
+        </FormField>
+
+        <!-- Label -->
+        <FormField label="Label" :error="errors.humanName" required>
+          <InputText v-model="humanName" type="text" placeholder="Label" />
+        </FormField>
+
+        <!-- Bid Floor (waterfall only) -->
+        <FormField
+          v-if="!isBidding"
+          label="Bid Floor"
+          :error="errors.bidFloor"
+          required
+        >
+          <InputNumber
+            v-model="bidFloor"
+            input-id="inlineBidFloor"
+            :min-fraction-digits="2"
+            :max-fraction-digits="5"
+            placeholder="0.00"
+          />
+        </FormField>
+
+        <!-- Network-specific extra fields -->
+        <LineItemExtraFormFields
+          v-model:schema="extraSchema"
+          :api-key="networkKey"
+          :ad-type="adType"
+          :ad-type-with-format="adTypeWithFormat"
+        />
+      </div>
+
+      <p v-if="submitError" class="text-xs text-red-500 mb-2">
+        {{ submitError }}
+      </p>
+
+      <div class="flex justify-end gap-2">
+        <button
+          type="button"
+          class="btn-cancel btn-sm"
+          @click="$emit('cancel')"
+        >
+          <i class="pi pi-times" /> Cancel
+        </button>
+        <Button
+          type="button"
+          :label="isEditMode ? 'Update' : 'Save'"
+          icon="pi pi-check"
+          size="small"
+          :loading="saving"
+          @click="save"
+        />
+      </div>
+    </template>
+
+    <div
+      v-if="!accountsLoading && !accounts.length"
+      class="flex justify-end mt-2"
+    >
+      <button type="button" class="btn-cancel btn-sm" @click="$emit('cancel')">
+        <i class="pi pi-times" /> Cancel
+      </button>
+    </div>
+  </div>
+</template>
+
+<script setup>
+import * as yup from "yup";
+import { NETWORK_ACCOUNT_TYPE_BY_KEY } from "@/constants/Networks.js";
+
+const props = defineProps({
+  appId: { type: [Number, String], required: true },
+  adType: { type: String, required: true },
+  networkKey: { type: String, required: true },
+  isBidding: { type: Boolean, required: true },
+  initialItem: { type: Object, default: null },
+});
+
+const emit = defineEmits(["created", "updated", "cancel"]);
+
+const isEditMode = computed(() => !!props.initialItem);
+
+const accountType = computed(
+  () => NETWORK_ACCOUNT_TYPE_BY_KEY[props.networkKey] ?? props.networkKey,
+);
+
+const adTypeWithFormat = computed(() => ({
+  adType: props.adType,
+  format: null,
+}));
+
+const extraSchema = ref(yup.object());
+
+const validationSchema = computed(() =>
+  yup.object({
+    humanName: yup.string().required().label("Label"),
+    accountId: yup.number().required().label("Account"),
+    bidFloor: props.isBidding
+      ? yup.number().nullable(true).label("Bid Floor")
+      : yup.number().required().positive().label("Bid Floor"),
+    extra: yup.lazy(() => extraSchema.value),
+  }),
+);
+
+const { errors, useFieldModel, handleSubmit } = useForm({
+  validationSchema,
+  initialValues: {
+    humanName: props.initialItem?.humanName ?? "",
+    accountId: props.initialItem?.accountId ?? null,
+    bidFloor: props.initialItem?.bidFloor ?? null,
+    extra: props.initialItem?.extra ?? {},
+  },
+});
+
+const humanName = useFieldModel("humanName");
+const accountId = useFieldModel("accountId");
+const bidFloor = useFieldModel("bidFloor");
+
+const accountsLoading = ref(true);
+const accounts = ref([]);
+
+onMounted(async () => {
+  try {
+    const data = await $apiFetch("/demand_source_accounts", {
+      params: { limit: 1000 },
+    });
+    const allAccounts = Array.isArray(data) ? data : (data.items ?? []);
+    accounts.value = allAccounts.filter((a) => a.type === accountType.value);
+    if (accounts.value.length === 1) {
+      accountId.value = accounts.value[0].id;
+    } else if (isEditMode.value && props.initialItem?.accountId) {
+      accountId.value = props.initialItem.accountId;
+    }
+  } finally {
+    accountsLoading.value = false;
+  }
+});
+
+const saving = ref(false);
+const submitError = ref("");
+
+const save = handleSubmit(async (values) => {
+  saving.value = true;
+  submitError.value = "";
+  try {
+    if (isEditMode.value) {
+      const data = await $apiFetch(`/line_items/${props.initialItem.id}`, {
+        method: "PATCH",
+        body: {
+          humanName: values.humanName,
+          accountId: values.accountId,
+          bidFloor: props.isBidding ? null : values.bidFloor,
+          extra: values.extra ?? {},
+        },
+      });
+      emit("updated", data);
+    } else {
+      const data = await $apiFetch("/line_items", {
+        method: "POST",
+        body: {
+          humanName: values.humanName,
+          appId: Number(props.appId),
+          adType: props.adType,
+          format: null,
+          accountId: values.accountId,
+          accountType: accountType.value,
+          isBidding: props.isBidding,
+          bidFloor: props.isBidding ? null : values.bidFloor,
+          extra: values.extra ?? {},
+        },
+      });
+      emit("created", data);
+    }
+  } catch (err) {
+    const msg = err.data?.error?.message;
+    submitError.value =
+      msg ||
+      (isEditMode.value
+        ? "Failed to update line item"
+        : "Failed to create line item");
+  } finally {
+    saving.value = false;
+  }
+});
+</script>

--- a/web/bidon_ui/components/auction_configurations/InlineLineItemForm.vue
+++ b/web/bidon_ui/components/auction_configurations/InlineLineItemForm.vue
@@ -168,7 +168,10 @@ onMounted(async () => {
       params: { limit: 1000 },
     });
     const allAccounts = Array.isArray(data) ? data : (data.items ?? []);
-    accounts.value = allAccounts.filter((a) => a.type === accountType.value);
+    const target = (accountType.value ?? "").toLowerCase();
+    accounts.value = allAccounts.filter(
+      (a) => (a.type ?? "").toLowerCase() === target,
+    );
     if (accounts.value.length === 1) {
       accountId.value = accounts.value[0].id;
     } else if (isEditMode.value && props.initialItem?.accountId) {

--- a/web/bidon_ui/components/resources/DestroyButton.vue
+++ b/web/bidon_ui/components/resources/DestroyButton.vue
@@ -1,6 +1,6 @@
 <template>
   <a href="_" @:click.prevent="() => deleteHandle(id)">
-    <Button label="Delete" icon="pi pi pi-trash" severity="danger" />
+    <Button label="Delete" icon="pi pi-trash" severity="danger" size="small" />
   </a>
 </template>
 

--- a/web/bidon_ui/pages/apps/[id]/index.vue
+++ b/web/bidon_ui/pages/apps/[id]/index.vue
@@ -2,77 +2,47 @@
   <PageContainer>
     <NavigationContainer>
       <GoBackButton :path="resourcesPath" />
-      <DestroyButton
-        v-if="resource._permissions.delete"
-        :id="id"
-        :path="resourcesPath"
-      />
-      <EditButton
-        v-if="resource._permissions.update"
-        :id="id"
-        :path="resourcesPath"
-      />
     </NavigationContainer>
-    <ResourceCard title="App" :fields="fields" :resource="resource" />
+
+    <AppOverviewCard
+      :id="id"
+      :resource="resource"
+      :resources-path="resourcesPath"
+    />
+
+    <AppDemandProfilesSection :demand-profiles="demandProfiles" :app-id="id" />
+
+    <AppAuctionConfigurationsSection
+      :initial-auction-configs="initialAuctionConfigs"
+      :initial-line-items="initialLineItems"
+      :app-id="id"
+    />
   </PageContainer>
 </template>
 
 <script setup>
 import axios from "@/services/ApiService.js";
-import { ResourceCardFields } from "@/constants";
 
 const route = useRoute();
 const id = route.params.id;
 const resourcesPath = "/apps";
 
-const response = await axios.get(`${resourcesPath}/${id}`);
-const resource = response.data;
+const [appResponse, configsData, lineItemsData, demandProfilesData] =
+  await Promise.all([
+    axios.get(`/apps/${id}`),
+    $apiFetch("/v2/auction_configurations_collection", {
+      params: { app_id: id, page: 1, limit: 200 },
+    }),
+    $apiFetch("/line_items_collection", {
+      params: { app_id: id, page: 1, limit: 1000 },
+    }),
+    $apiFetch("/app_demand_profiles_collection", {
+      params: { app_id: id, page: 1, limit: 200 },
+    }),
+  ]);
 
-const fields = [
-  { ...ResourceCardFields.PublicUid, copyable: true },
-  { label: "App Key", key: "appKey", copyable: true },
-  ResourceCardFields.Owner,
-  { label: "App Name", key: "humanName" },
-  { label: "Platform", key: "platformId" },
-  { label: "Package Name", key: "packageName" },
-  { label: "Store ID", key: "storeId" },
-  { label: "Store URL", key: "storeUrl" },
-  { label: "Categories", key: "categories" },
-  { label: "Blocked Advertiser Domains", key: "badv" },
-  { label: "Blocked Categories", key: "bcat" },
-  { label: "Blocked Apps", key: "bapp" },
-  {
-    key: "lineItems",
-    label: "Line Items",
-    type: "associatedResourcesLink",
-    associatedResourcesLink: {
-      extractLinkData: ({ id }) => ({
-        label: "Line Items",
-        path: `/line_items?appId=${id}`,
-      }),
-    },
-  },
-  {
-    key: "appDemandProfiles",
-    label: "App Demand Profiles",
-    type: "associatedResourcesLink",
-    associatedResourcesLink: {
-      extractLinkData: ({ id }) => ({
-        label: "App Demand Profiles",
-        path: `/app_demand_profiles?appId=${id}`,
-      }),
-    },
-  },
-  {
-    key: "auctionConfigurations",
-    label: "Auction Configurations",
-    type: "associatedResourcesLink",
-    associatedResourcesLink: {
-      extractLinkData: ({ id }) => ({
-        label: "Auction Configurations",
-        path: `/v2/auction_configurations?appId=${id}`,
-      }),
-    },
-  },
-];
+const resource = appResponse.data;
+const demandProfiles = demandProfilesData.items ?? [];
+const initialAuctionConfigs = configsData.items ?? [];
+const initialLineItems = lineItemsData.items ?? [];
 </script>


### PR DESCRIPTION
 - App overview page with inline auction config, line item, and demand profile editing 
    - Refactor apps/[id]/index.vue into AppOverviewCard + section components
    - Add AppAuctionConfigurationsSection: collapsible auction configs with inline create/edit/clone
    - Add AppDemandProfilesSection: inline demand source profile create/edit per network
    - Add InlineAuctionConfigForm, InlineLineItemForm, InlineDemandProfileForm
    - Add AuctionConfigNetworkSection for per-network line item display within a config
    - Fix DestroyButton icon class (duplicate pi prefix) and add small size