### PR TITLE
[APDM-2241] Exclude line items of disabled networks from auctions

### DIFF
--- a/internal/auction/store/ad_units_matcher.go
+++ b/internal/auction/store/ad_units_matcher.go
@@ -43,11 +43,16 @@ func (m *AdUnitsMatcher) Match(ctx context.Context, params *auction.BuildParams)
 		WithContext(ctx).
 		Select("bid_floor", "line_items.human_name", "line_items.bidding", "line_items.extra", "line_items.public_uid").
 		Where(map[string]any{
-			"app_id":  params.App.ID,
-			"ad_type": db.AdTypeFromDomain(params.AdType),
+			"line_items.app_id":  params.App.ID,
+			"line_items.ad_type": db.AdTypeFromDomain(params.AdType),
 		}).
 		InnerJoins("Account", m.DB.Select("id")).
-		InnerJoins("Account.DemandSource", m.DB.Select("api_key").Where(map[string]any{"api_key": params.Adapters}))
+		InnerJoins("Account.DemandSource", m.DB.Select("api_key").Where(map[string]any{"api_key": params.Adapters})).
+		Joins(`INNER JOIN app_demand_profiles adp
+		         ON adp.app_id     = line_items.app_id
+		        AND adp.account_id = line_items.account_id
+		        AND adp.enabled    = TRUE
+		        AND adp.deleted_at IS NULL`)
 
 	if params.PriceFloor >= 0 {
 		query = query.Where("(bid_floor >= ? OR line_items.bidding)", params.PriceFloor)

--- a/internal/auction/store/ad_units_matcher_test.go
+++ b/internal/auction/store/ad_units_matcher_test.go
@@ -52,6 +52,17 @@ func TestAdUnitsMatcher_Match(t *testing.T) {
 		account.DemandSource = bidmachineDemandSource
 	})
 
+	for i := range apps {
+		dbtest.CreateAppDemandProfile(t, tx, func(p *db.AppDemandProfile) {
+			p.App = apps[i]
+			p.Account = applovinAccount
+		})
+		dbtest.CreateAppDemandProfile(t, tx, func(p *db.AppDemandProfile) {
+			p.App = apps[i]
+			p.Account = bidmachineAccount
+		})
+	}
+
 	applovinInterstitialAdUnitID := int64(1234567890)
 	lineItems := []db.LineItem{
 		{
@@ -496,5 +507,100 @@ func TestAdUnitsMatcher_Match(t *testing.T) {
 		if diff := cmp.Diff(tC.want, got, cmpopts.SortSlices(less)); diff != "" {
 			t.Errorf("matcher.Match(ctx, %+v) mismatch (-want, +got)\n%s", tC.params, diff)
 		}
+	}
+}
+
+func TestAdUnitsMatcher_Match_SkipsDisabledAppDemandProfile(t *testing.T) {
+	tx := testDB.Begin()
+	defer tx.Rollback()
+
+	rdb, _ := redismock.NewClusterMock()
+
+	app := dbtest.CreateApp(t, tx)
+
+	applovinDemandSource := dbtest.CreateDemandSource(t, tx, func(source *db.DemandSource) {
+		source.APIKey = string(adapter.ApplovinKey)
+	})
+	applovinAccount := dbtest.CreateDemandSourceAccount(t, tx, func(account *db.DemandSourceAccount) {
+		account.DemandSource = applovinDemandSource
+	})
+
+	bidmachineDemandSource := dbtest.CreateDemandSource(t, tx, func(source *db.DemandSource) {
+		source.APIKey = string(adapter.BidmachineKey)
+	})
+	bidmachineAccount := dbtest.CreateDemandSourceAccount(t, tx, func(account *db.DemandSourceAccount) {
+		account.DemandSource = bidmachineDemandSource
+	})
+
+	// Applovin profile is enabled, Bidmachine profile is disabled.
+	dbtest.CreateAppDemandProfile(t, tx, func(p *db.AppDemandProfile) {
+		p.App = app
+		p.Account = applovinAccount
+	})
+	disabled := false
+	dbtest.CreateAppDemandProfile(t, tx, func(p *db.AppDemandProfile) {
+		p.App = app
+		p.Account = bidmachineAccount
+		p.Enabled = &disabled
+	})
+
+	lineItems := []db.LineItem{
+		{
+			AppID:     app.ID,
+			AdType:    db.InterstitialAdType,
+			HumanName: "applovin-interstitial",
+			BidFloor:  decimal.NewNullDecimal(decimal.RequireFromString("0.3")),
+			AccountID: applovinAccount.ID,
+			PublicUID: sql.NullInt64{Int64: 1701972528521547900, Valid: true},
+			Extra:     map[string]any{"placement_id": "applovin-interstitial"},
+		},
+		{
+			AppID:     app.ID,
+			AdType:    db.InterstitialAdType,
+			HumanName: "bidmachine-interstitial",
+			BidFloor:  decimal.NewNullDecimal(decimal.RequireFromString("0.0")),
+			AccountID: bidmachineAccount.ID,
+			IsBidding: sql.NullBool{Bool: true, Valid: true},
+			PublicUID: sql.NullInt64{Int64: 1701972528521547901, Valid: true},
+		},
+	}
+	if err := tx.Create(&lineItems).Error; err != nil {
+		t.Fatalf("Error creating line items: %v", err)
+	}
+
+	matcher := store.AdUnitsMatcher{
+		DB:    tx,
+		Cache: config.NewRedisCacheOf[[]auction.AdUnit](rdb, time.Minute, "ad units"),
+	}
+
+	// Pass both adapter keys, mimicking an upstream filter that has not yet
+	// propagated the disabled state (e.g. a stale cache).
+	params := &auction.BuildParams{
+		App:        testApp(app.ID),
+		AdType:     ad.InterstitialType,
+		AdFormat:   ad.EmptyFormat,
+		DeviceType: device.PhoneType,
+		Adapters:   []adapter.Key{adapter.ApplovinKey, adapter.BidmachineKey},
+	}
+
+	got, err := matcher.Match(context.Background(), params)
+	if err != nil {
+		t.Fatalf("Match() error: %v", err)
+	}
+
+	want := []auction.AdUnit{
+		{
+			DemandID:   "applovin",
+			UID:        "1701972528521547900",
+			PriceFloor: ptr(0.3),
+			Label:      "applovin-interstitial",
+			BidType:    schema.CPMBidType,
+			Timeout:    store.AdUnitTimeout,
+			Extra:      map[string]any{"placement_id": "applovin-interstitial"},
+		},
+	}
+	less := func(a, b auction.AdUnit) bool { return a.Label < b.Label }
+	if diff := cmp.Diff(want, got, cmpopts.SortSlices(less)); diff != "" {
+		t.Errorf("Match() returned line items for disabled profile (-want, +got):\n%s", diff)
 	}
 }

--- a/internal/auction/store/config_fetcher.go
+++ b/internal/auction/store/config_fetcher.go
@@ -166,7 +166,12 @@ func (m *ConfigFetcher) FetchBidMachinePlacements(ctx context.Context, appID int
 		Joins("JOIN auction_configurations ac ON li.id = ANY(ac.ad_unit_ids)").
 		Joins("JOIN demand_source_accounts dsa ON li.account_id = dsa.id").
 		Joins("JOIN demand_sources ds ON dsa.demand_source_id = ds.id").
-		Where("ac.id IN (?) AND ds.api_key = ? AND li.extra->>'placement' IS NOT NULL AND li.extra->>'placement' != ''", configIDs, "bidmachine").
+		Joins(`JOIN app_demand_profiles adp
+		         ON adp.app_id     = li.app_id
+		        AND adp.account_id = li.account_id
+		        AND adp.enabled    = TRUE
+		        AND adp.deleted_at IS NULL`).
+		Where("ac.id IN (?) AND ds.api_key = ? AND li.deleted_at IS NULL AND li.extra->>'placement' IS NOT NULL AND li.extra->>'placement' != ''", configIDs, "bidmachine").
 		Scan(&results).
 		Error
 	if err != nil {

--- a/internal/auction/store/config_fetcher_test.go
+++ b/internal/auction/store/config_fetcher_test.go
@@ -418,6 +418,17 @@ func TestConfigFetcher_FetchBidMachinePlacements(t *testing.T) {
 		account.DemandSource = otherDemandSource
 	})
 
+	for i := range apps {
+		dbtest.CreateAppDemandProfile(t, tx, func(p *db.AppDemandProfile) {
+			p.App = apps[i]
+			p.Account = bidmachineAccount
+		})
+		dbtest.CreateAppDemandProfile(t, tx, func(p *db.AppDemandProfile) {
+			p.App = apps[i]
+			p.Account = otherAccount
+		})
+	}
+
 	// Create line items with BidMachine placements
 	lineItem1 := dbtest.CreateLineItem(t, tx, func(item *db.LineItem) {
 		item.App = apps[0]
@@ -570,6 +581,11 @@ func TestConfigFetcher_FetchBidMachinePlacements_MultipleLineItemsSameAuctionKey
 		account.DemandSource = bidmachineDemandSource
 	})
 
+	dbtest.CreateAppDemandProfile(t, tx, func(p *db.AppDemandProfile) {
+		p.App = app
+		p.Account = bidmachineAccount
+	})
+
 	// Create multiple line items with different placements
 	lineItem1 := dbtest.CreateLineItem(t, tx, func(item *db.LineItem) {
 		item.App = app
@@ -639,6 +655,11 @@ func TestConfigFetcher_FetchBidMachinePlacements_EdgeCases(t *testing.T) {
 	// Create demand source account
 	bidmachineAccount := dbtest.CreateDemandSourceAccount(t, tx, func(account *db.DemandSourceAccount) {
 		account.DemandSource = bidmachineDemandSource
+	})
+
+	dbtest.CreateAppDemandProfile(t, tx, func(p *db.AppDemandProfile) {
+		p.App = app
+		p.Account = bidmachineAccount
 	})
 
 	// Create line item with empty placement
@@ -746,6 +767,15 @@ func TestConfigFetcher_FetchBidMachinePlacements_NoBidMachineConfigs(t *testing.
 		account.DemandSource = dtexchangeDemandSource
 	})
 
+	dbtest.CreateAppDemandProfile(t, tx, func(p *db.AppDemandProfile) {
+		p.App = app
+		p.Account = gamAccount
+	})
+	dbtest.CreateAppDemandProfile(t, tx, func(p *db.AppDemandProfile) {
+		p.App = app
+		p.Account = dtexchangeAccount
+	})
+
 	// Create line items with placements (but not BidMachine)
 	lineItem1 := dbtest.CreateLineItem(t, tx, func(item *db.LineItem) {
 		item.App = app
@@ -815,6 +845,11 @@ func TestConfigFetcher_FetchBidMachinePlacements_MissingPlacement(t *testing.T) 
 	// Create demand source account
 	bidmachineAccount := dbtest.CreateDemandSourceAccount(t, tx, func(account *db.DemandSourceAccount) {
 		account.DemandSource = bidmachineDemandSource
+	})
+
+	dbtest.CreateAppDemandProfile(t, tx, func(p *db.AppDemandProfile) {
+		p.App = app
+		p.Account = bidmachineAccount
 	})
 
 	// Create line items with different placement scenarios
@@ -906,5 +941,110 @@ func TestConfigFetcher_FetchBidMachinePlacements_MissingPlacement(t *testing.T) 
 	// Verify that we got exactly 2 results (from configs with PublicUID 1 and 4)
 	if len(got) != 2 {
 		t.Errorf("Expected 2 placements, got %d: %v", len(got), got)
+	}
+}
+
+func TestConfigFetcher_FetchBidMachinePlacements_DisabledProfile(t *testing.T) {
+	tx := testDB.Begin()
+	defer tx.Rollback()
+
+	app := dbtest.CreateApp(t, tx)
+
+	bidmachineDemandSource := dbtest.CreateDemandSource(t, tx, func(source *db.DemandSource) {
+		source.APIKey = "bidmachine"
+		source.HumanName = "BidMachine"
+	})
+	bidmachineAccount := dbtest.CreateDemandSourceAccount(t, tx, func(account *db.DemandSourceAccount) {
+		account.DemandSource = bidmachineDemandSource
+	})
+
+	disabled := false
+	dbtest.CreateAppDemandProfile(t, tx, func(p *db.AppDemandProfile) {
+		p.App = app
+		p.Account = bidmachineAccount
+		p.Enabled = &disabled
+	})
+
+	lineItem := dbtest.CreateLineItem(t, tx, func(item *db.LineItem) {
+		item.App = app
+		item.Account = bidmachineAccount
+		item.Extra = map[string]any{"placement": "placement-x"}
+	})
+
+	config := db.AuctionConfiguration{
+		AppID:      app.ID,
+		PublicUID:  sql.NullInt64{Int64: 1, Valid: true},
+		AdType:     db.BannerAdType,
+		AuctionKey: "auction-key-disabled",
+		Demands:    pq.StringArray{"bidmachine"},
+		AdUnitIds:  pq.Int64Array{lineItem.ID},
+	}
+	if err := tx.Create(&config).Error; err != nil {
+		t.Fatalf("Error creating config: %v", err)
+	}
+
+	fetcher := &store.ConfigFetcher{DB: tx}
+	got, err := fetcher.FetchBidMachinePlacements(context.Background(), app.ID)
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+
+	want := map[string]string{}
+	if diff := cmp.Diff(want, got); diff != "" {
+		t.Errorf("FetchBidMachinePlacements() returned placements for disabled profile (-want, +got):\n%s", diff)
+	}
+}
+
+func TestConfigFetcher_FetchBidMachinePlacements_SoftDeletedLineItem(t *testing.T) {
+	tx := testDB.Begin()
+	defer tx.Rollback()
+
+	app := dbtest.CreateApp(t, tx)
+
+	bidmachineDemandSource := dbtest.CreateDemandSource(t, tx, func(source *db.DemandSource) {
+		source.APIKey = "bidmachine"
+		source.HumanName = "BidMachine"
+	})
+	bidmachineAccount := dbtest.CreateDemandSourceAccount(t, tx, func(account *db.DemandSourceAccount) {
+		account.DemandSource = bidmachineDemandSource
+	})
+
+	dbtest.CreateAppDemandProfile(t, tx, func(p *db.AppDemandProfile) {
+		p.App = app
+		p.Account = bidmachineAccount
+	})
+
+	lineItem := dbtest.CreateLineItem(t, tx, func(item *db.LineItem) {
+		item.App = app
+		item.Account = bidmachineAccount
+		item.Extra = map[string]any{"placement": "placement-soft-deleted"}
+	})
+
+	config := db.AuctionConfiguration{
+		AppID:      app.ID,
+		PublicUID:  sql.NullInt64{Int64: 1, Valid: true},
+		AdType:     db.BannerAdType,
+		AuctionKey: "auction-key-soft-deleted",
+		Demands:    pq.StringArray{"bidmachine"},
+		AdUnitIds:  pq.Int64Array{lineItem.ID},
+	}
+	if err := tx.Create(&config).Error; err != nil {
+		t.Fatalf("Error creating config: %v", err)
+	}
+
+	// Soft-delete the line item (sets deleted_at).
+	if err := tx.Delete(&lineItem).Error; err != nil {
+		t.Fatalf("Error soft-deleting line item: %v", err)
+	}
+
+	fetcher := &store.ConfigFetcher{DB: tx}
+	got, err := fetcher.FetchBidMachinePlacements(context.Background(), app.ID)
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+
+	want := map[string]string{}
+	if diff := cmp.Diff(want, got); diff != "" {
+		t.Errorf("FetchBidMachinePlacements() returned placements from soft-deleted line item (-want, +got):\n%s", diff)
 	}
 }

--- a/internal/sdkapi/store/store.go
+++ b/internal/sdkapi/store/store.go
@@ -191,9 +191,14 @@ func (f *AdapterInitConfigsFetcher) fetchAmazonSlots(ctx context.Context, appID 
 	err := f.DB.
 		WithContext(ctx).
 		Select("line_items.id, line_items.extra, line_items.ad_type, line_items.format").
-		Where("app_id", appID).
+		Where("line_items.app_id", appID).
 		InnerJoins("Account", f.DB.Select("id")).
 		InnerJoins("Account.DemandSource", f.DB.Select("api_key").Where("api_key", adapter.AmazonKey)).
+		Joins(`INNER JOIN app_demand_profiles adp
+		         ON adp.app_id     = line_items.app_id
+		        AND adp.account_id = line_items.account_id
+		        AND adp.enabled    = TRUE
+		        AND adp.deleted_at IS NULL`).
 		Order("line_items.id").
 		Find(&dbLineItems).
 		Error
@@ -316,9 +321,14 @@ func (f *AdapterInitConfigsFetcher) fetchLineItems(ctx context.Context, appID in
 	err := f.DB.
 		WithContext(ctx).
 		Select("line_items.id, line_items.public_uid, line_items.extra, line_items.bid_floor, line_items.ad_type, line_items.format, line_items.bidding").
-		Where("app_id", appID).
+		Where("line_items.app_id", appID).
 		InnerJoins("Account", f.DB.Select("id")).
 		InnerJoins("Account.DemandSource", f.DB.Select("api_key").Where("api_key", adapterKey)).
+		Joins(`INNER JOIN app_demand_profiles adp
+		         ON adp.app_id     = line_items.app_id
+		        AND adp.account_id = line_items.account_id
+		        AND adp.enabled    = TRUE
+		        AND adp.deleted_at IS NULL`).
 		Order("line_items.id").
 		Find(&lineItems).
 		Error

--- a/internal/sdkapi/store/store_test.go
+++ b/internal/sdkapi/store/store_test.go
@@ -576,6 +576,11 @@ func TestAdapterInitConfigsFetcher_FetchTaurusXPlacements(t *testing.T) {
 		account.DemandSourceID = taurusxDemandSource.ID
 	})
 
+	dbtest.CreateAppDemandProfile(t, tx, func(p *db.AppDemandProfile) {
+		p.App = app
+		p.Account = taurusxAccount
+	})
+
 	// Create line items with placement_id and different ad types
 	dbtest.CreateLineItem(t, tx, func(item *db.LineItem) {
 		item.AppID = app.ID
@@ -643,6 +648,11 @@ func TestAdapterInitConfigsFetcher_FetchTaurusXPlacements_MissingPlacementID(t *
 		account.DemandSourceID = taurusxDemandSource.ID
 	})
 
+	dbtest.CreateAppDemandProfile(t, tx, func(p *db.AppDemandProfile) {
+		p.App = app
+		p.Account = taurusxAccount
+	})
+
 	// Create line item WITHOUT placement_id
 	dbtest.CreateLineItem(t, tx, func(item *db.LineItem) {
 		item.AppID = app.ID
@@ -686,6 +696,11 @@ func TestAdapterInitConfigsFetcher_FetchBiddingZmaticooPlacements(t *testing.T) 
 	zmaticooAccount := dbtest.CreateDemandSourceAccount(t, tx, func(account *db.DemandSourceAccount) {
 		account.DemandSource = zmaticooDemandSource
 		account.DemandSourceID = zmaticooDemandSource.ID
+	})
+
+	dbtest.CreateAppDemandProfile(t, tx, func(p *db.AppDemandProfile) {
+		p.App = app
+		p.Account = zmaticooAccount
 	})
 
 	// Create line items with placement_id and different ad types
@@ -767,6 +782,11 @@ func TestAdapterInitConfigsFetcher_FetchBiddingZmaticooPlacements_MissingPlaceme
 		account.DemandSourceID = zmaticooDemandSource.ID
 	})
 
+	dbtest.CreateAppDemandProfile(t, tx, func(p *db.AppDemandProfile) {
+		p.App = app
+		p.Account = zmaticooAccount
+	})
+
 	// Create line item WITHOUT placement_id and bidding enabled
 	dbtest.CreateLineItem(t, tx, func(item *db.LineItem) {
 		item.AppID = app.ID
@@ -842,5 +862,83 @@ func TestAdapterInitConfigsFetcher_FetchApplovinAdUnitIDs(t *testing.T) {
 
 	if diff := cmp.Diff(want, got); diff != "" {
 		t.Errorf("FetchAdapterInitConfigs() mismatch (-want +got):\n%s", diff)
+	}
+}
+
+func TestAdapterInitConfigsFetcher_fetchLineItems_SkipsDisabledProfile(t *testing.T) {
+	tx := testDB.Begin()
+	defer tx.Rollback()
+
+	app := dbtest.CreateApp(t, tx)
+
+	taurusxDemandSource := dbtest.CreateDemandSource(t, tx, func(ds *db.DemandSource) {
+		ds.APIKey = "taurusx"
+	})
+	taurusxAccount := dbtest.CreateDemandSourceAccount(t, tx, func(account *db.DemandSourceAccount) {
+		account.DemandSource = taurusxDemandSource
+	})
+
+	disabled := false
+	dbtest.CreateAppDemandProfile(t, tx, func(p *db.AppDemandProfile) {
+		p.App = app
+		p.Account = taurusxAccount
+		p.Enabled = &disabled
+	})
+
+	dbtest.CreateLineItem(t, tx, func(item *db.LineItem) {
+		item.App = app
+		item.Account = taurusxAccount
+		item.AdType = db.InterstitialAdType
+		item.Extra = map[string]any{"placement_id": "placement-disabled"}
+	})
+
+	rdb, _ := redismock.NewClusterMock()
+	lineItemsCache := config.NewRedisCacheOf[[]db.LineItem](rdb, 10*time.Minute, "line_items")
+	fetcher := &AdapterInitConfigsFetcher{DB: tx, LineItemsCache: lineItemsCache}
+
+	got, err := fetcher.fetchLineItems(context.Background(), app.ID, adapter.TaurusXKey)
+	if err != nil {
+		t.Fatalf("fetchLineItems() error: %v", err)
+	}
+	if len(got) != 0 {
+		t.Errorf("fetchLineItems() returned %d line items for disabled profile, want 0", len(got))
+	}
+}
+
+func TestAdapterInitConfigsFetcher_fetchAmazonSlots_SkipsDisabledProfile(t *testing.T) {
+	tx := testDB.Begin()
+	defer tx.Rollback()
+
+	app := dbtest.CreateApp(t, tx)
+
+	amazonDemandSource := dbtest.CreateDemandSource(t, tx, func(ds *db.DemandSource) {
+		ds.APIKey = string(adapter.AmazonKey)
+	})
+	amazonAccount := dbtest.CreateDemandSourceAccount(t, tx, func(account *db.DemandSourceAccount) {
+		account.DemandSource = amazonDemandSource
+	})
+
+	disabled := false
+	dbtest.CreateAppDemandProfile(t, tx, func(p *db.AppDemandProfile) {
+		p.App = app
+		p.Account = amazonAccount
+		p.Enabled = &disabled
+	})
+
+	dbtest.CreateLineItem(t, tx, func(item *db.LineItem) {
+		item.App = app
+		item.Account = amazonAccount
+		item.AdType = db.BannerAdType
+		item.Extra = map[string]any{"slot_uuid": "amazon_slot_x", "format": "BANNER"}
+	})
+
+	fetcher := &AdapterInitConfigsFetcher{DB: tx}
+
+	got, err := fetcher.fetchAmazonSlots(context.Background(), app.ID)
+	if err != nil {
+		t.Fatalf("fetchAmazonSlots() error: %v", err)
+	}
+	if len(got) != 0 {
+		t.Errorf("fetchAmazonSlots() returned %d slots for disabled profile, want 0", len(got))
 	}
 }


### PR DESCRIPTION
## Summary
- Disabling a network on an `AppDemandProfile` did not stop its line items from being matched during auctions or returned via `/config`, because line-item queries joined only through `demand_source_accounts` and never checked `app_demand_profiles.enabled`.
- Added an `INNER JOIN app_demand_profiles ON app_id + account_id WHERE enabled = TRUE AND deleted_at IS NULL` to every direct line-item query: `AdUnitsMatcher.Match`, `ConfigFetcher.FetchBidMachinePlacements`, `fetchAmazonSlots`, and `fetchLineItems` (TaurusX / Zmaticoo).
- Added regression tests with disabled-profile fixtures for each path, and AppDemandProfile fixtures where they were missing so upstream tests continue to pass under the new JOIN.

## Context
Reported at `https://app.bidon.org/v2/auction_configurations/8102/edit` (auction key `1OHMJUFUO0000`, JoinBlocks Android). That specific config was hand-fixed; this PR removes the code-level bug.

The auction path was partially masked by the upstream `FetchEnabledAdapterKeys` filter at `auction/service.go:107`, but that mask breaks when the profiles cache is stale after an admin toggle, or when any caller bypasses it. `FetchBidMachinePlacements` (called from `/config`) had no upstream gate at all.

## Design note
The JOIN keys only on `app_id + account_id` (not `account_type`) because `account_id` is already a FK to `demand_source_accounts.id` — the composite match is redundant and made the query brittle against fixtures that did not populate `account_type`.

## Test plan
- [x] `go test ./internal/auction/... ./internal/sdkapi/... ./internal/bidding/...` → 362 passed / 0 failed across 39 packages
- [x] New regression tests:
  - `TestAdUnitsMatcher_Match_SkipsDisabledAppDemandProfile`
  - `TestConfigFetcher_FetchBidMachinePlacements_DisabledProfile`
  - `TestAdapterInitConfigsFetcher_fetchLineItems_SkipsDisabledProfile`
  - `TestAdapterInitConfigsFetcher_fetchAmazonSlots_SkipsDisabledProfile`
- [x] Pre-merge: run the audit query below on staging to count line items that will be newly excluded; flag any apps with unexpected drops.

```sql
SELECT li.app_id,
       COUNT(*) FILTER (WHERE adp.id IS NULL)      AS orphan_no_profile,
       COUNT(*) FILTER (WHERE adp.enabled = FALSE) AS will_be_filtered,
       COUNT(*)                                    AS total_line_items
FROM line_items li
LEFT JOIN app_demand_profiles adp
  ON adp.app_id = li.app_id AND adp.account_id = li.account_id AND adp.deleted_at IS NULL
WHERE li.deleted_at IS NULL
GROUP BY 1
HAVING COUNT(*) FILTER (WHERE adp.id IS NULL OR adp.enabled = FALSE) > 0
ORDER BY 2 + 3 DESC
LIMIT 50;
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)