### PR TITLE
Add PR auto-approve workflow for 'approve please' comments

### DIFF
--- a/.github/workflows/pr-auto-approve.yml
+++ b/.github/workflows/pr-auto-approve.yml
@@ -1,0 +1,19 @@
+name: pr
+
+on:
+  issue_comment:
+    types: [created, edited]
+
+permissions:
+  pull-requests: write
+  contents: read
+
+jobs:
+  approve:
+    if: ${{ github.event.issue.pull_request && github.event.comment.body == 'approve please' && (github.event.comment.author_association == 'OWNER' || github.event.comment.author_association == 'MEMBER' || github.event.comment.author_association == 'COLLABORATOR') }}
+    runs-on: [self-hosted, main]
+    steps:
+      - name: PR approve
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: gh pr review https://github.com/${{ github.repository }}/pull/${{ github.event.issue.number }} --approve


### PR DESCRIPTION
## Summary
- Adds `.github/workflows/pr-auto-approve.yml`. When a repository OWNER / MEMBER / COLLABORATOR comments `approve please` on a PR, the workflow approves it via `gh pr review --approve`.
- Triggers on `issue_comment` (created or edited). Runs on `self-hosted, main`.
- Uses the default `GITHUB_TOKEN` with `pull-requests: write` + `contents: read`.

## Test plan
- [ ] After merge, open a test PR and comment `approve please` from an authorized account; confirm the workflow runs and the PR is approved.
- [ ] Comment `approve please` from an unauthorized account (e.g. external contributor); confirm the job is skipped by the `if:` guard.
- [ ] Edit an existing comment to match `approve please`; confirm the `edited` event also triggers approval.

🤖 Generated with [Claude Code](https://claude.com/claude-code)