### PR TITLE
BAC-7 add adikteev network 2

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -4,7 +4,9 @@ DATABASE_URL=postgres://bidon:pass@localhost:5434/bidon
 DATABASE_REPLICA_URL=postgres://bidon:pass@localhost:5434/bidon
 ENVIRONMENT=development
 SENTRY_DSN=
-MAXMIND_GEOIP_FILE_PATH=public/system/GeoLite2-City.mmdb
+MAXMIND_GEOIP_FILE_PATH=GeoLite2-City.mmdb
+MAXMIND_GEOIP_ACCOUNT_ID=
+MAXMIND_GEOIP_LICENSE_KEY=
 USE_GEOCODING=true
 APP_SECRET=app_secret
 SUPERUSER_LOGIN=login
@@ -42,3 +44,4 @@ AWS_SECRET_ACCESS_KEY=xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
 
 # Copilot settings
 COPILOT_BASE_URL=127.0.0.1:8123
+

--- a/.env.sample
+++ b/.env.sample
@@ -45,3 +45,5 @@ AWS_SECRET_ACCESS_KEY=xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
 # Copilot settings
 COPILOT_BASE_URL=127.0.0.1:8123
 
+# docker-compose.staging.yml / Coolify: Traefik basic auth for Redpanda Console (whole htpasswd line; set as secret).
+# REDPANDA_CONSOLE_BA_USERS=

--- a/.env.staging.example
+++ b/.env.staging.example
@@ -1,0 +1,16 @@
+# Staging environment — configure in Coolify (http://coolify.bidon.squads.com/)
+# Copy to .env.staging for local reference or bidon-coolify --env-file usage.
+
+# Managed Postgres connection (from: terraform output -raw db_app_private_uri)
+DATABASE_URL=postgres://bidon:password@host:25060/bidon?sslmode=require
+
+# Application secrets
+APP_SECRET=
+SUPERUSER_LOGIN=
+SUPERUSER_PASSWORD=
+
+# Docker image tags — set to the git SHA from `just ci-build-*` (or a CI build tag)
+BIDON_ADMIN_TAG=
+BIDON_SDKAPI_TAG=
+BIDON_MIGRATE_TAG=
+BIDON_SEED_TAG=

--- a/.github/workflows/go-run-tests.yml
+++ b/.github/workflows/go-run-tests.yml
@@ -22,7 +22,7 @@ jobs:
           token: ${{ secrets.CODECOV_BIDON_BACKEND_TOKEN }}
           url: ${{ secrets.CODECOV_URL }}
           directory: ./testcov/
-          fail_ci_if_error: true
+          fail_ci_if_error: false # TODO: this is failing, Could not verify signature. Please contact Codecov if problem continues
 
       - run: docker compose down --rmi local -v
         if: always()

--- a/.github/workflows/pre-commit-checks.yml
+++ b/.github/workflows/pre-commit-checks.yml
@@ -20,7 +20,7 @@ jobs:
         # TODO: remove once Coolify deploy key is added to bidon-protos (see .gitmodules).
         # update=none prevents automatic submodule init, so we override it here explicitly.
         - name: Initialize proto submodule
-          run: git -c submodule.proto.update=checkout submodule update --init proto
+          run: git -c submodule.proto.update=checkout submodule update --init --recursive proto
 
         - name: Run pre-commit checks
           run: docker compose run --rm go-pre-commit

--- a/.gitignore
+++ b/.gitignore
@@ -14,8 +14,8 @@
 
 # Envs
 .env
-.env.test
 .env.local
+.env.test
 .env.staging
 .env.prod
 /**/.env

--- a/.gitignore
+++ b/.gitignore
@@ -28,6 +28,7 @@
 .DS_Store
 
 public/system
+/GeoLite2-*.mmdb
 
 # Ignore files related to Rust.
 target

--- a/.gitmodules
+++ b/.gitmodules
@@ -2,5 +2,5 @@
 	path = proto
 	url = git@github.com:bidon-io/bidon-protos.git
 	# TODO: remove update=none once a Coolify deploy key is added to bidon-protos (requires repo admin access).
-	# To pull the submodule locally: git submodule update --init proto
+	# To pull the submodule locally: git submodule update --init --recursive proto
 	update = none

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,85 @@
+# Agent Instructions
+
+Practical guidance for AI agents working in the Bidon backend codebase.
+
+For full architecture, patterns, and code templates, see [CLAUDE.md](CLAUDE.md).
+
+## Project Overview
+
+Bidon is a **Go-based ad mediation and programmatic advertising platform** handling RTB auctions, ad unit management, demand source adapters, and event tracking.
+
+**Key Technologies:**
+- Language: Go
+- Database: PostgreSQL (with GORM ORM)
+- Caching: Redis
+- Messaging: Redpanda (Kafka-compatible API)
+- APIs: REST (Echo framework) + gRPC
+- Protocol Buffers: For API definitions
+
+## Local Development
+
+### Full local stack (recommended)
+
+```bash
+docker compose -f docker-compose.dev.yml up -d
+```
+
+Runs Postgres, Redis, Redpanda, migrations, seed data, both API services, and the Nuxt frontend.
+
+| Service          | URL                   |
+|------------------|-----------------------|
+| bidon-ui         | http://localhost:3010 |
+| bidon-admin      | http://localhost:1323 |
+| bidon-sdkapi     | http://localhost:1324 |
+| Postgres         | localhost:5434        |
+| Redpanda         | localhost:19092     |
+| Redpanda Console | http://localhost:8080 |
+
+### Manual setup (dependencies only)
+
+```bash
+make local-init
+docker compose up -d
+```
+
+Starts Postgres and Redis. Use the full dev stack above for Redpanda.
+
+### Running services directly
+
+```bash
+go run ./cmd/bidon-admin
+go run ./cmd/bidon-sdkapi
+```
+
+### Migrations
+
+```bash
+go run ./cmd/bidon-migrate up
+```
+
+### Tests
+
+```bash
+make test
+go test ./internal/auction/...
+```
+
+## Key Concepts
+
+- **Repository pattern** for all data access (`internal/*/store/*_repo.go`)
+- **Service layer** for business logic (`internal/*/service.go`)
+- **User scoping** via `ListOwnedByUser()` / `FindOwnedByUser()` for multi-tenancy
+- **Event logging** to Redpanda for analytics (auction, impression, click events)
+
+## Code Style
+
+- Follow standard Go conventions; use `golangci-lint`
+- Interfaces defined in consuming packages
+- Context as first parameter; explicit error handling (no panics in production)
+- Generate mocks with `go generate ./...` (moq)
+
+## Verification Checklist
+
+- Run targeted tests in changed packages
+- Run `make test` when contracts or shared logic change
+- Confirm no lint errors on touched files

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,7 +15,7 @@ Bidon is a **Go-based ad mediation and programmatic advertising platform** that 
 - Language: Go
 - Database: PostgreSQL (with GORM ORM)
 - Caching: Redis
-- Messaging: Kafka
+- Messaging: Redpanda (Kafka-compatible API)
 - APIs: REST (Echo framework) + gRPC
 - Protocol Buffers: For API definitions
 
@@ -224,7 +224,10 @@ func (h *Handler) HandleRequest(ctx context.Context, req *Request) (*Response, e
 # Initialize local environment
 make local-init
 
-# Start dependencies (Postgres, Redis, Kafka)
+# Full local stack (Postgres, Redis, Redpanda, APIs, UI)
+docker compose -f docker-compose.dev.yml up -d
+
+# Or start core dependencies only (Postgres, Redis)
 docker compose up -d
 ```
 
@@ -284,7 +287,7 @@ Resources are typically scoped to users:
 6. Handles win/loss notifications
 
 ### Event Logging
-Events are logged to Kafka for analytics:
+Events are logged to Redpanda for analytics:
 - Auction events
 - Impression events
 - Click events

--- a/README.md
+++ b/README.md
@@ -78,6 +78,53 @@ go run ./cmd/bidon-sdkapi
 make test
 ```
 
+## Docker images
+
+Images are tagged with the current git SHA and named `registry.digitalocean.com/bidon-io/<service>:<sha>`.
+
+### Local builds (testing)
+
+Build images into your local Docker store for `docker run` or compose testing. No registry login or push:
+
+```shell
+just build-admin    # bidon-admin
+just build-sdkapi   # bidon-sdkapi
+just build-migrate  # bidon-migrate
+just build-seed     # bidon-seed
+just build-all      # all of the above
+```
+
+### CI / registry builds (staging and deploy)
+
+Build and push to the DigitalOcean Container Registry. Authenticate first:
+
+```shell
+just docker-login
+```
+
+Push a single service:
+
+```shell
+just ci-build-admin
+just ci-build-sdkapi
+just ci-build-migrate
+just ci-build-seed
+```
+
+Or push all services (logs in once):
+
+```shell
+just ci-build-all
+```
+
+### Staging deployment
+
+Staging runs in [Coolify](http://coolify.bidon.squads.com/).
+
+After pushing images with `just ci-build-*`, update the app configuration there — set each `BIDON_*_TAG` environment variable to the git SHA produced by the build. See `.env.staging.example` for the full list of required variables.
+
+For initial Coolify setup (Terraform provisioning, `bidon-coolify` CLI), see `infra/README.md`.
+
 ### Clean env
 ```shell
 docker compose down --volumes --rmi local --remove-orphans || true

--- a/cmd/bidon-seed/sample_seeds/20260323121000_sample_apps_and_configurations.sql
+++ b/cmd/bidon-seed/sample_seeds/20260323121000_sample_apps_and_configurations.sql
@@ -604,7 +604,7 @@ BEGIN
         created_at, updated_at, segment_id, external_win_notifications, public_uid,
         timeout, demands, bidding, ad_unit_ids
     ) VALUES (
-    6050, 'Tetris Banner Config', tetris_app_id, 3, '[]'::jsonb, 1, '{"v2": true}'::jsonb, 0.15,
+    6050, 'Tetris Banner Auction', tetris_app_id, 3, '[]'::jsonb, 1, '{"v2": true}'::jsonb, 0.15,
     NOW(), NOW(), NULL, false, 6050, 10000,
     ARRAY['adikteev']::varchar[],
     ARRAY['adikteev']::varchar[],

--- a/cmd/bidon-seed/sample_seeds/20260323121000_sample_apps_and_configurations.sql
+++ b/cmd/bidon-seed/sample_seeds/20260323121000_sample_apps_and_configurations.sql
@@ -590,6 +590,8 @@ BEGIN
     --
     -- Auction strategy:
     --   Banner        — Adikteev bidding
+    --   Interstitial  — Adikteev bidding
+    --   Rewarded      — Adikteev bidding
     -- =========================================================
     INSERT INTO line_items (
         id, app_id, account_type, account_id, human_name, bid_floor, ad_type, extra,

--- a/cmd/bidon-seed/sample_seeds/20260323121000_sample_apps_and_configurations.sql
+++ b/cmd/bidon-seed/sample_seeds/20260323121000_sample_apps_and_configurations.sql
@@ -167,7 +167,7 @@ BEGIN
     (4011, spacerunner_app_id, 'DemandSourceAccount::Meta', meta_account_id, meta_id,
      '{"app_id": 876543210}'::jsonb, NOW(), NOW(), 4011, true),
     -- Tetris
-    (4012, tetris_app_id, 'DemandSourceAccount::adikteev', adikteev_account_id, adikteev_id,
+    (4012, tetris_app_id, 'DemandSourceAccount::Adikteev', adikteev_account_id, adikteev_id,
      '{"app_id": 195876}'::jsonb, NOW(), NOW(), 4012, true)
     ON CONFLICT (id) DO NOTHING;
 

--- a/cmd/bidon-seed/sample_seeds/20260323121000_sample_apps_and_configurations.sql
+++ b/cmd/bidon-seed/sample_seeds/20260323121000_sample_apps_and_configurations.sql
@@ -24,6 +24,7 @@ DECLARE
     admob_id      BIGINT;
     unityads_id   BIGINT;
     meta_id       BIGINT;
+    adikteev_id   BIGINT;
 
     -- Owner: use the first existing admin user (e.g. from init-admin.sh),
     -- falling back to the demo admin user (1000) inserted above.
@@ -35,6 +36,7 @@ DECLARE
     trivial_app_id     BIGINT := 2002;
     wordpuzzle_app_id  BIGINT := 2003;
     spacerunner_app_id BIGINT := 2004;
+    tetris_app_id      BIGINT := 2005;
 
     -- Demand source account IDs
     bidmachine_account_id BIGINT := 3000;
@@ -42,6 +44,7 @@ DECLARE
     admob_account_id      BIGINT := 3002;
     unityads_account_id   BIGINT := 3003;
     meta_account_id       BIGINT := 3004;
+    adikteev_account_id   BIGINT := 3005;
 BEGIN
     -- Resolve owner: prefer an existing admin user, fall back to demo user 1000.
     SELECT id INTO owner_id FROM users WHERE is_admin = true ORDER BY id LIMIT 1;
@@ -55,12 +58,14 @@ BEGIN
     SELECT id INTO admob_id      FROM demand_sources WHERE api_key = 'admob';
     SELECT id INTO unityads_id   FROM demand_sources WHERE api_key = 'unityads';
     SELECT id INTO meta_id       FROM demand_sources WHERE api_key = 'meta';
+    SELECT id INTO adikteev_id   FROM demand_sources WHERE api_key = 'adikteev';
 
     IF bidmachine_id IS NULL THEN RAISE EXCEPTION 'BidMachine demand source not found. Run demand_sources seed first.'; END IF;
     IF applovin_id   IS NULL THEN RAISE EXCEPTION 'AppLovin demand source not found. Run demand_sources seed first.'; END IF;
     IF admob_id      IS NULL THEN RAISE EXCEPTION 'AdMob demand source not found. Run demand_sources seed first.'; END IF;
     IF unityads_id   IS NULL THEN RAISE EXCEPTION 'Unity Ads demand source not found. Run demand_sources seed first.'; END IF;
     IF meta_id       IS NULL THEN RAISE EXCEPTION 'Meta demand source not found. Run demand_sources seed first.'; END IF;
+    IF adikteev_id   IS NULL THEN RAISE EXCEPTION 'Adikteev demand source not found. Run demand_sources seed first.'; END IF;
 
     -- =========================================================
     -- Demand Source Accounts (all owned by owner_id)
@@ -97,6 +102,12 @@ BEGIN
         'DemandSourceAccount::meta',
         '{}'::jsonb,
         false, false, NOW(), NOW(), 'Meta Audience Network', meta_account_id
+    ),
+    (
+        adikteev_account_id, adikteev_id, owner_id,
+        'DemandSourceAccount::adikteev',
+        '{"endpoint": "rubicon-eu.dsp.adikteev.com", "seller_id":  "1"}'::jsonb,
+        true, false, NOW(), NOW(), 'Adikteev Audience Network', adikteev_account_id
     )
     ON CONFLICT (id) DO NOTHING;
 
@@ -110,7 +121,8 @@ BEGIN
     (mahjong_app_id,     owner_id, 4, 'Mahjong Quest',           'com.demo.mahjongquest',   'mahjong_'     || mahjong_app_id,     '{}'::jsonb, NOW(), NOW(), mahjong_app_id),
     (trivial_app_id,     owner_id, 1, 'Trivial Pursuit Ultimate', 'com.demo.trivialpursuit', 'trivial_'     || trivial_app_id,     '{}'::jsonb, NOW(), NOW(), trivial_app_id),
     (wordpuzzle_app_id,  owner_id, 4, 'Word Puzzle Pro',         'com.demo.wordpuzzlepro',  'wordpuzzle_'  || wordpuzzle_app_id,  '{}'::jsonb, NOW(), NOW(), wordpuzzle_app_id),
-    (spacerunner_app_id, owner_id, 1, 'Space Runner',            'com.demo.spacerunner',    'spacerunner_' || spacerunner_app_id, '{}'::jsonb, NOW(), NOW(), spacerunner_app_id)
+    (spacerunner_app_id, owner_id, 1, 'Space Runner',            'com.demo.spacerunner',    'spacerunner_' || spacerunner_app_id, '{}'::jsonb, NOW(), NOW(), spacerunner_app_id),
+    (tetris_app_id,      owner_id, 1, 'Tetris',                  'com.demo.tetris',         'tetris_' || tetris_app_id,           '{}'::jsonb, NOW(), NOW(), tetris_app_id)
     ON CONFLICT (id) DO NOTHING;
 
     -- =========================================================
@@ -120,6 +132,7 @@ BEGIN
     -- Trivial:      BidMachine, AdMob
     -- Word Puzzle:  Unity Ads, Meta
     -- Space Runner: Unity Ads, Meta
+    -- Tetris:       Adikteev
     -- =========================================================
     INSERT INTO app_demand_profiles (
         id, app_id, account_type, account_id, demand_source_id, data, created_at, updated_at, public_uid, enabled
@@ -152,7 +165,10 @@ BEGIN
     (4010, spacerunner_app_id, 'DemandSourceAccount::UnityAds', unityads_account_id, unityads_id,
      '{"game_id": 5123456}'::jsonb, NOW(), NOW(), 4010, true),
     (4011, spacerunner_app_id, 'DemandSourceAccount::Meta', meta_account_id, meta_id,
-     '{"app_id": 876543210}'::jsonb, NOW(), NOW(), 4011, true)
+     '{"app_id": 876543210}'::jsonb, NOW(), NOW(), 4011, true),
+    -- Tetris
+    (4012, tetris_app_id, 'DemandSourceAccount::adikteev', adikteev_account_id, adikteev_id,
+     '{"app_id": 195876}'::jsonb, NOW(), NOW(), 4012, true)
     ON CONFLICT (id) DO NOTHING;
 
     -- =========================================================
@@ -567,6 +583,32 @@ BEGIN
         ARRAY['unityads']::varchar[],
         ARRAY['unityads']::varchar[],
         ARRAY[5200, 5201, 5202, 5203]::bigint[]
+    ) ON CONFLICT (id) DO NOTHING;
+
+    -- =========================================================
+    -- TETRIS
+    --
+    -- Auction strategy:
+    --   Banner        — Adikteev bidding
+    -- =========================================================
+    INSERT INTO line_items (
+        id, app_id, account_type, account_id, human_name, bid_floor, ad_type, extra,
+        created_at, updated_at, width, height, format, public_uid, bidding
+    ) VALUES
+    (5301, tetris_app_id, 'DemandSourceAccount::adikteev', adikteev_account_id,
+     'Tetris Adikteev Banner [Bidding]', 0.01, 3, '{"placement_id": "4567822365_banner_bid"}'::jsonb, NOW(), NOW(), 320, 480, 'BANNER', 5301, true)
+    ON CONFLICT (id) DO NOTHING;
+
+    INSERT INTO auction_configurations (
+        id, name, app_id, ad_type, rounds, status, settings, pricefloor,
+        created_at, updated_at, segment_id, external_win_notifications, public_uid,
+        timeout, demands, bidding, ad_unit_ids
+    ) VALUES (
+    6050, 'Tetris Banner Config', tetris_app_id, 3, '[]'::jsonb, 1, '{"v2": true}'::jsonb, 0.15,
+    NOW(), NOW(), NULL, false, 6050, 10000,
+    ARRAY['adikteev']::varchar[],
+    ARRAY['adikteev']::varchar[],
+    ARRAY[5301]::bigint[]
     ) ON CONFLICT (id) DO NOTHING;
 
 END $$;

--- a/cmd/bidon-seed/sample_seeds/20260323121000_sample_apps_and_configurations.sql
+++ b/cmd/bidon-seed/sample_seeds/20260323121000_sample_apps_and_configurations.sql
@@ -106,7 +106,7 @@ BEGIN
     (
         adikteev_account_id, adikteev_id, owner_id,
         'DemandSourceAccount::adikteev',
-        '{"endpoint": "rubicon-eu.dsp.adikteev.com", "seller_id":  "1"}'::jsonb,
+        '{}'::jsonb,
         true, false, NOW(), NOW(), 'Adikteev Audience Network', adikteev_account_id
     )
     ON CONFLICT (id) DO NOTHING;
@@ -168,7 +168,7 @@ BEGIN
      '{"app_id": 876543210}'::jsonb, NOW(), NOW(), 4011, true),
     -- Tetris
     (4012, tetris_app_id, 'DemandSourceAccount::Adikteev', adikteev_account_id, adikteev_id,
-     '{"app_id": 195876}'::jsonb, NOW(), NOW(), 4012, true)
+     '{"sdk_instance_id": "sdk_instance_id"}'::jsonb, NOW(), NOW(), 4012, true)
     ON CONFLICT (id) DO NOTHING;
 
     -- =========================================================
@@ -596,7 +596,15 @@ BEGIN
         created_at, updated_at, width, height, format, public_uid, bidding
     ) VALUES
     (5301, tetris_app_id, 'DemandSourceAccount::adikteev', adikteev_account_id,
-     'Tetris Adikteev Banner [Bidding]', 0.01, 3, '{"placement_id": "4567822365_banner_bid"}'::jsonb, NOW(), NOW(), 320, 480, 'BANNER', 5301, true)
+     'Tetris Adikteev Banner [Bidding]', 0.01, 3, '{}'::jsonb, NOW(), NOW(), 320, 50, 'BANNER', 5301, true)
+    ON CONFLICT (id) DO NOTHING;
+
+    INSERT INTO line_items (
+        id, app_id, account_type, account_id, human_name, bid_floor, ad_type, extra,
+        created_at, updated_at, width, height, format, public_uid, bidding
+    ) VALUES
+    (5302, tetris_app_id, 'DemandSourceAccount::adikteev', adikteev_account_id,
+     'Tetris Adikteev MREC [Bidding]', 0.01, 3, '{}'::jsonb, NOW(), NOW(), 300, 250, 'MREC', 5302, true)
     ON CONFLICT (id) DO NOTHING;
 
     INSERT INTO auction_configurations (
@@ -608,7 +616,47 @@ BEGIN
     NOW(), NOW(), NULL, false, 6050, 10000,
     ARRAY['adikteev']::varchar[],
     ARRAY['adikteev']::varchar[],
-    ARRAY[5301]::bigint[]
+    ARRAY[5301, 5302]::bigint[]
+    ) ON CONFLICT (id) DO NOTHING;
+
+    INSERT INTO line_items (
+        id, app_id, account_type, account_id, human_name, bid_floor, ad_type, extra,
+        created_at, updated_at, width, height, format, public_uid, bidding
+    ) VALUES
+    (5303, tetris_app_id, 'DemandSourceAccount::adikteev', adikteev_account_id,
+     'Tetris Adikteev Interstitial [Bidding]', 0.01, 1, '{}'::jsonb, NOW(), NOW(), 320, 480, '', 5303, true)
+    ON CONFLICT (id) DO NOTHING;
+
+    INSERT INTO auction_configurations (
+        id, name, app_id, ad_type, rounds, status, settings, pricefloor,
+        created_at, updated_at, segment_id, external_win_notifications, public_uid,
+        timeout, demands, bidding, ad_unit_ids
+    ) VALUES (
+    6051, 'Tetris Interstitial Auction', tetris_app_id, 1, '[]'::jsonb, 1, '{"v2": true}'::jsonb, 0.15,
+    NOW(), NOW(), NULL, false, 6051, 10000,
+    ARRAY['adikteev']::varchar[],
+    ARRAY['adikteev']::varchar[],
+    ARRAY[5303]::bigint[]
+    ) ON CONFLICT (id) DO NOTHING;
+
+    INSERT INTO line_items (
+        id, app_id, account_type, account_id, human_name, bid_floor, ad_type, extra,
+        created_at, updated_at, width, height, format, public_uid, bidding
+    ) VALUES
+    (5304, tetris_app_id, 'DemandSourceAccount::adikteev', adikteev_account_id,
+     'Tetris Adikteev Rewarded [Bidding]', 0.01, 6, '{}'::jsonb, NOW(), NOW(), 0, 0, '', 5304, true)
+    ON CONFLICT (id) DO NOTHING;
+
+    INSERT INTO auction_configurations (
+        id, name, app_id, ad_type, rounds, status, settings, pricefloor,
+        created_at, updated_at, segment_id, external_win_notifications, public_uid,
+        timeout, demands, bidding, ad_unit_ids
+    ) VALUES (
+    6052, 'Tetris Rewarded Auction', tetris_app_id, 6, '[]'::jsonb, 1, '{"v2": true}'::jsonb, 0.15,
+    NOW(), NOW(), NULL, false, 6052, 10000,
+    ARRAY['adikteev']::varchar[],
+    ARRAY['adikteev']::varchar[],
+    ARRAY[5304]::bigint[]
     ) ON CONFLICT (id) DO NOTHING;
 
 END $$;

--- a/cmd/bidon-seed/seeds/20250325114723_demand_sources.sql
+++ b/cmd/bidon-seed/seeds/20250325114723_demand_sources.sql
@@ -22,7 +22,8 @@ VALUES
 ('vkads', 'VK Ads', NOW(), NOW()),
 ('vungle', 'Vungle', NOW(), NOW()),
 ('yandex', 'Yandex', NOW(), NOW()),
-('zmaticoo', 'Zmaticoo', NOW(), NOW())
+('zmaticoo', 'Zmaticoo', NOW(), NOW()),
+('adikteev', 'Adikteev', NOW(), NOW())
 ON CONFLICT (api_key) DO NOTHING;
 -- +goose StatementEnd
 

--- a/docker-compose-prod.yml
+++ b/docker-compose-prod.yml
@@ -10,11 +10,18 @@ services:
   geodb-maxmind:
     image: maxmindinc/geoipupdate:v4.7.1
     environment:
-      GEOIPUPDATE_ACCOUNT_ID: ${MAXMIND_ACCOUNT_ID}
-      GEOIPUPDATE_LICENSE_KEY: ${MAXMIND_LICENSE_KEY}
+      GEOIPUPDATE_ACCOUNT_ID: ${MAXMIND_GEOIP_ACCOUNT_ID}
+      GEOIPUPDATE_LICENSE_KEY: ${MAXMIND_GEOIP_LICENSE_KEY}
       GEOIPUPDATE_EDITION_IDS: GeoLite2-City
+      GEOIPUPDATE_FREQUENCY: 72
     volumes:
       - "geodb:/usr/share/GeoIP/"
+    healthcheck:
+      test: ["CMD-SHELL", "test -f /usr/share/GeoIP/GeoLite2-City.mmdb"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 30s
 
   postgres:
     image: postgres:17.2

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -97,6 +97,12 @@ services:
         condition: service_healthy
     environment:
       KAFKA_BROKERS: redpanda:9092
+    healthcheck:
+      test: ["CMD-SHELL", "wget -q --spider http://127.0.0.1:8080/admin/health || exit 1"]
+      interval: 15s
+      timeout: 5s
+      retries: 5
+      start_period: 15s
 
   migrate:
     image: golang:1.24-alpine

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -14,7 +14,7 @@ x-dev-db-env: &dev-db-env
 
 x-dev-kafka-env: &dev-kafka-env
   USE_KAFKA: "true"
-  KAFKA_BROKERS_LIST: kafka:29092
+  KAFKA_BROKERS_LIST: redpanda:9092
   KAFKA_CLIENT_ID: bidon_dev
   KAFKA_DELIVERY_INTERVAL: 5
   KAFKA_AD_EVENTS_TOPIC: ad-events
@@ -29,7 +29,8 @@ x-redis-cluster-env: &redis-cluster-env
 x-dev-bidon-app-env: &dev-bidon-app-env
   <<: [*dev-kafka-env, *redis-cluster-env]
   ENVIRONMENT: development
-  USE_GEOCODING: "false"
+  USE_GEOCODING: "true"
+  MAXMIND_GEOIP_FILE_PATH: GeoLite2-City.mmdb
   SNOWFLAKE_NODE_ID: 1
 
 x-dev-superuser-env: &dev-superuser-env
@@ -63,37 +64,39 @@ services:
       - redis-data-dev:/data
     extra_hosts: *host-gateway-extra-hosts
 
-  zookeeper:
-    image: confluentinc/cp-zookeeper:7.2.1
-    hostname: zookeeper
+  redpanda:
+    image: docker.redpanda.com/redpandadata/redpanda:v26.1.9
+    command:
+      - redpanda
+      - start
+      - --kafka-addr internal://0.0.0.0:9092,external://0.0.0.0:19092
+      - --advertise-kafka-addr internal://redpanda:9092,external://localhost:19092
+      - --rpc-addr redpanda:33145
+      - --advertise-rpc-addr redpanda:33145
+      - --mode dev-container
+      - --smp 1
+      - --default-log-level=warn
+    ports:
+      - '19092:19092'
+      - '9644:9644'
+    volumes:
+      - redpanda-data-dev:/var/lib/redpanda/data
     healthcheck:
-      test: echo srvr | nc zookeeper 2181 || exit 1
-      retries: 20
-      interval: 10s
-    ports:
-      - '2181:2181'
-    environment:
-      ZOOKEEPER_CLIENT_PORT: 2181
-      ZOOKEEPER_TICK_TIME: 2000
+      test: ["CMD-SHELL", "rpk cluster health | grep -E 'Healthy:.+true' || exit 1"]
+      interval: 15s
+      timeout: 3s
+      retries: 5
+      start_period: 5s
 
-  kafka:
-    image: confluentinc/cp-kafka:7.2.1
-    hostname: kafka
-    depends_on:
-      - zookeeper
+  redpanda-console:
+    image: docker.redpanda.com/redpandadata/console:v2.8.15
     ports:
-      - '9092:9092'
-      - '9093:9093'
+      - '8080:8080'
+    depends_on:
+      redpanda:
+        condition: service_healthy
     environment:
-      KAFKA_BROKER_ID: 1
-      KAFKA_ZOOKEEPER_CONNECT: 'zookeeper:2181'
-      KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: PLAINTEXT:PLAINTEXT,PLAINTEXT_INTERNAL:PLAINTEXT,EXTERNAL_DOCKER:PLAINTEXT
-      KAFKA_LISTENERS: PLAINTEXT://:9092,PLAINTEXT_INTERNAL://:29092,EXTERNAL_DOCKER://:9093
-      KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://localhost:9092,PLAINTEXT_INTERNAL://kafka:29092,EXTERNAL_DOCKER://host.docker.internal:9093
-      KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 1
-      KAFKA_GROUP_INITIAL_REBALANCE_DELAY_MS: 0
-      KAFKA_TRANSACTION_STATE_LOG_MIN_ISR: 1
-      KAFKA_TRANSACTION_STATE_LOG_REPLICATION_FACTOR: 1
+      KAFKA_BROKERS: redpanda:9092
 
   migrate:
     image: golang:1.24-alpine
@@ -127,8 +130,8 @@ services:
         condition: service_completed_successfully
       redis:
         condition: service_started
-      kafka:
-        condition: service_started
+      redpanda:
+        condition: service_healthy
     environment:
       <<: [*dev-db-env, *dev-bidon-app-env, *dev-superuser-env]
       PORT: 1323
@@ -147,8 +150,8 @@ services:
         condition: service_completed_successfully
       redis:
         condition: service_started
-      kafka:
-        condition: service_started
+      redpanda:
+        condition: service_healthy
     environment:
       <<: [*dev-db-env, *dev-bidon-app-env]
       PORT: 1323
@@ -188,9 +191,11 @@ services:
       - ./scripts/init-admin.sh:/init-admin.sh
     command: sh /init-admin.sh
 
+
 volumes:
   pgdata-dev:
   gomodcache-dev:
   gocache-dev:
   redis-data-dev:
+  redpanda-data-dev:
   bidon-ui-node-modules-dev:

--- a/docker-compose.staging.yml
+++ b/docker-compose.staging.yml
@@ -8,10 +8,14 @@ x-logging: &default-logging
   driver: json-file
 
 # Required env vars (set in .env or Coolify environment):
-#   DATABASE_URL          — from: terraform output -raw db_app_private_uri
-#   APP_SECRET            — random secret for session signing
-#   SUPERUSER_LOGIN       — initial admin username
-#   SUPERUSER_PASSWORD    — initial admin password
+#   DATABASE_URL              — from: terraform output -raw db_app_private_uri
+#   APP_SECRET                — random secret for session signing
+#   SUPERUSER_LOGIN           — initial admin username
+#   SUPERUSER_PASSWORD        — initial admin password
+#   BIDON_ADMIN_TAG           — Docker image tag for bidon-admin (e.g. git SHA from CI)
+#   BIDON_SDKAPI_TAG          — Docker image tag for bidon-sdkapi
+#   BIDON_MIGRATE_TAG         — Docker image tag for bidon-migrate
+#   BIDON_SEED_TAG            — Docker image tag for bidon-seed
 #   MAXMIND_GEOIP_ACCOUNT_ID  — MaxMind account ID for GeoLite2-City updates
 #   MAXMIND_GEOIP_LICENSE_KEY — MaxMind license key for GeoLite2-City updates
 
@@ -95,9 +99,7 @@ services:
     <<: *restart-policy
 
   migrate:
-    build:
-      context: .
-      target: bidon-migrate
+    image: "registry.digitalocean.com/bidon-io/bidon-migrate:${BIDON_MIGRATE_TAG}"
     command: up
     restart: on-failure
     environment:
@@ -105,9 +107,7 @@ services:
     logging: *default-logging
 
   bidon-admin:
-    build:
-      context: .
-      target: bidon-admin
+    image: "registry.digitalocean.com/bidon-io/bidon-admin:${BIDON_ADMIN_TAG}"
     ports:
       - "1323:1323"
       - "50051:50051"
@@ -129,9 +129,7 @@ services:
     <<: *restart-policy
 
   bidon-sdkapi:
-    build:
-      context: .
-      target: bidon-sdkapi
+    image: "registry.digitalocean.com/bidon-io/bidon-sdkapi:${BIDON_SDKAPI_TAG}"
     ports:
       - "1324:1323"
     depends_on:
@@ -153,9 +151,7 @@ services:
     <<: *restart-policy
 
   bidon-seed:
-    build:
-      context: .
-      target: bidon-seed
+    image: "registry.digitalocean.com/bidon-io/bidon-seed:${BIDON_SEED_TAG}"
     command: ["/bidon-seed", "--sample", "--reset"]
     depends_on:
       migrate:

--- a/docker-compose.staging.yml
+++ b/docker-compose.staging.yml
@@ -18,6 +18,12 @@ x-logging: &default-logging
 #   BIDON_SEED_TAG            — Docker image tag for bidon-seed
 #   MAXMIND_GEOIP_ACCOUNT_ID  — MaxMind account ID for GeoLite2-City updates
 #   MAXMIND_GEOIP_LICENSE_KEY — MaxMind license key for GeoLite2-City updates
+#   REDPANDA_CONSOLE_BA_USERS — Traefik basicAuth.users for redpanda-console only (never commit).
+#     Generate: htpasswd -nbBC 10 <user> '<password>'  →  one line: user:$2y$10$...
+#     Coolify: reference this var under redpanda-console.environment (below) so it is in the
+#     deployment .env and ${REDPANDA_CONSOLE_BA_USERS} in labels is interpolated — labels-only refs can stay literal.
+#     For bcrypt, mark the value “literal” in Coolify if $ characters get stripped.
+#     Gitignored .env beside compose: if Compose treats $ inside values as substitution, escape with $$ per $ in the hash segment.
 
 x-staging-db-env: &staging-db-env
   DATABASE_URL: ${DATABASE_URL}
@@ -72,9 +78,6 @@ services:
       - --node-id 0
       - --kafka-addr PLAINTEXT://0.0.0.0:29092,OUTSIDE://0.0.0.0:9092
       - --advertise-kafka-addr PLAINTEXT://redpanda:29092,OUTSIDE://localhost:9092
-    ports:
-      - "9092:9092"
-      - "29092:29092"
     volumes:
       - redpanda-data:/var/lib/redpanda/data
     healthcheck:
@@ -86,10 +89,32 @@ services:
     logging: *default-logging
     <<: *restart-policy
 
+  # Redpanda Console (UI): expose publicly via Coolify → Traefik; protect with Basic Auth middleware
+  # labels only on this service. Kafka brokers stay at redpanda:29092 without proxy auth — see Coolify docs:
+  # https://coolify.io/docs/knowledge-base/proxy/traefik/basic-auth#docker-compose-and-services
+  redpanda-console:
+    image: redpandadata/console:v2.8.15
+    expose:
+      - "8080"
+    depends_on:
+      redpanda:
+        condition: service_healthy
+    environment:
+      KAFKA_BROKERS: redpanda:29092
+    healthcheck:
+      test: ["CMD-SHELL", "wget -q --spider http://127.0.0.1:8080/admin/health || exit 1"]
+      interval: 15s
+      timeout: 5s
+      retries: 5
+      start_period: 15s
+    labels:
+      - "traefik.http.middlewares.redpanda-console-ba.basicauth.users=${REDPANDA_CONSOLE_BA_USERS}"
+      - "coolify.traefik.middlewares=redpanda-console-ba"
+    logging: *default-logging
+    <<: *restart-policy
+
   redis:
     image: redis:7-alpine
-    ports:
-      - "6379:6379"
     volumes:
       - redis-data:/data
     healthcheck:
@@ -108,9 +133,9 @@ services:
 
   bidon-admin:
     image: "registry.digitalocean.com/bidon-io/bidon-admin:${BIDON_ADMIN_TAG}"
-    ports:
-      - "1323:1323"
-      - "50051:50051"
+    expose:
+      - "1323"
+      - "50051"
     depends_on:
       migrate:
         condition: service_completed_successfully
@@ -130,8 +155,8 @@ services:
 
   bidon-sdkapi:
     image: "registry.digitalocean.com/bidon-io/bidon-sdkapi:${BIDON_SDKAPI_TAG}"
-    ports:
-      - "1324:1323"
+    expose:
+      - "1323"
     depends_on:
       geodb-maxmind:
         condition: service_healthy

--- a/docker-compose.staging.yml
+++ b/docker-compose.staging.yml
@@ -8,10 +8,12 @@ x-logging: &default-logging
   driver: json-file
 
 # Required env vars (set in .env or Coolify environment):
-#   DATABASE_URL        — from: terraform output -raw db_app_private_uri
-#   APP_SECRET          — random secret for session signing
-#   SUPERUSER_LOGIN     — initial admin username
-#   SUPERUSER_PASSWORD  — initial admin password
+#   DATABASE_URL          — from: terraform output -raw db_app_private_uri
+#   APP_SECRET            — random secret for session signing
+#   SUPERUSER_LOGIN       — initial admin username
+#   SUPERUSER_PASSWORD    — initial admin password
+#   MAXMIND_GEOIP_ACCOUNT_ID  — MaxMind account ID for GeoLite2-City updates
+#   MAXMIND_GEOIP_LICENSE_KEY — MaxMind license key for GeoLite2-City updates
 
 x-staging-db-env: &staging-db-env
   DATABASE_URL: ${DATABASE_URL}
@@ -32,12 +34,31 @@ x-staging-redis-env: &staging-redis-env
 x-staging-bidon-app-env: &staging-bidon-app-env
   <<: [*staging-kafka-env, *staging-redis-env]
   ENVIRONMENT: production
-  USE_GEOCODING: "false"
+  USE_GEOCODING: "true"
+  MAXMIND_GEOIP_FILE_PATH: /public/system/GeoLite2-City.mmdb
   SNOWFLAKE_NODE_ID: 1
 
 services:
+  geodb-maxmind:
+    image: maxmindinc/geoipupdate:v4.7.1
+    environment:
+      GEOIPUPDATE_ACCOUNT_ID: ${MAXMIND_GEOIP_ACCOUNT_ID}
+      GEOIPUPDATE_LICENSE_KEY: ${MAXMIND_GEOIP_LICENSE_KEY}
+      GEOIPUPDATE_EDITION_IDS: GeoLite2-City
+      GEOIPUPDATE_FREQUENCY: 72
+    volumes:
+      - geodb:/usr/share/GeoIP
+    healthcheck:
+      test: ["CMD-SHELL", "test -f /usr/share/GeoIP/GeoLite2-City.mmdb"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 30s
+    logging: *default-logging
+    <<: *restart-policy
+
   redpanda:
-    image: redpandadata/redpanda:latest
+    image: redpandadata/redpanda:v26.1.9
     command:
       - redpanda
       - start
@@ -114,6 +135,8 @@ services:
     ports:
       - "1324:1323"
     depends_on:
+      geodb-maxmind:
+        condition: service_healthy
       migrate:
         condition: service_completed_successfully
       redis:
@@ -124,6 +147,8 @@ services:
       <<: [*staging-db-env, *staging-bidon-app-env]
       PORT: 1323
       APP_SECRET: ${APP_SECRET}
+    volumes:
+      - geodb:/public/system
     logging: *default-logging
     <<: *restart-policy
 
@@ -156,5 +181,6 @@ services:
     logging: *default-logging
 
 volumes:
+  geodb:
   redpanda-data:
   redis-data:

--- a/flake.nix
+++ b/flake.nix
@@ -18,6 +18,8 @@
             pkgs.go
             pkgs.golangci-lint
             pkgs.just
+            pkgs.buf
+            pkgs.pre-commit
           ];
 
           shellHook = '' [ ! -f .env ] && cp .env.sample .env.local && ln -s .env.local .env '';

--- a/infra/README.md
+++ b/infra/README.md
@@ -95,6 +95,8 @@ Then open `http://<droplet_ip>:8000`, create the admin user, and generate an API
 
 ### Step 4 — Configure Bidon apps (bidon-coolify)
 
+Images must be built and pushed to `registry.digitalocean.com/bidon-io` before creating apps (see root `README.md` for `just ci-build-*` recipes). Use the git SHA from the build as `--image-tag`.
+
 ```bash
 export COOLIFY_BASE_URL="http://$(terraform output -raw droplet_ipv4):8000"
 export COOLIFY_API_KEY="<your-api-key>"
@@ -117,8 +119,8 @@ go run ./cmd/bidon-coolify create-app \
   --github-app-uuid <github_app_uuid> \
   --name bidon-admin \
   --git-repository https://github.com/bidon-io/bidon-backend \
-  --image-name ghcr.io/bidon-io/bidon-admin \
-  --image-tag latest \
+  --image-name registry.digitalocean.com/bidon-io/bidon-admin \
+  --image-tag <git-sha> \
   --ports-exposes 1323 \
   --health-check-path /health \
   --health-check-port 1323

--- a/internal/adapter/adapter.go
+++ b/internal/adapter/adapter.go
@@ -14,6 +14,7 @@ type Config struct {
 
 const (
 	// Sorted alphabetically
+	Adikteev      Key = "adikteev"
 	AdmobKey      Key = "admob"
 	AmazonKey     Key = "amazon"
 	ApplovinKey   Key = "applovin"
@@ -38,6 +39,7 @@ const (
 )
 
 var Keys = []Key{
+	Adikteev,
 	AdmobKey,
 	AmazonKey,
 	ApplovinKey,

--- a/internal/adapter/adapter.go
+++ b/internal/adapter/adapter.go
@@ -14,7 +14,7 @@ type Config struct {
 
 const (
 	// Sorted alphabetically
-	Adikteev      Key = "adikteev"
+	AdikteevKey   Key = "adikteev"
 	AdmobKey      Key = "admob"
 	AmazonKey     Key = "amazon"
 	ApplovinKey   Key = "applovin"
@@ -39,7 +39,7 @@ const (
 )
 
 var Keys = []Key{
-	Adikteev,
+	AdikteevKey,
 	AdmobKey,
 	AmazonKey,
 	ApplovinKey,

--- a/internal/bidding/adapters/adikteev/adikteev.go
+++ b/internal/bidding/adapters/adikteev/adikteev.go
@@ -179,6 +179,8 @@ func (a *AdikteevAdapter) ExecuteRequest(ctx context.Context, client *http.Clien
 
 func (a *AdikteevAdapter) ParseBids(dr *adapters.DemandResponse) (*adapters.DemandResponse, error) {
 	switch dr.Status {
+	case http.StatusNoContent:
+		return dr, nil
 	case http.StatusOK:
 		break
 	default:

--- a/internal/bidding/adapters/adikteev/adikteev.go
+++ b/internal/bidding/adapters/adikteev/adikteev.go
@@ -32,9 +32,13 @@ var bannerFormats = map[ad.Format][2]int64{
 	ad.MRECFormat:   {300, 250},
 }
 
-func (a *AdikteevAdapter) banner(auctionRequest *schema.AuctionRequest) *openrtb2.Imp {
-	size := bannerFormats[auctionRequest.AdObject.Format()]
+var MRAIDAPI = []adcom1.APIFramework{adcom1.APIMRAID10, adcom1.APIMRAID20}
 
+func (a *AdikteevAdapter) banner(auctionRequest *schema.AuctionRequest) *openrtb2.Imp {
+	size, found := bannerFormats[auctionRequest.AdObject.Format()]
+	if !found {
+		return nil
+	}
 	w, h := size[0], size[1]
 
 	return &openrtb2.Imp{
@@ -43,13 +47,16 @@ func (a *AdikteevAdapter) banner(auctionRequest *schema.AuctionRequest) *openrtb
 			W:   &w,
 			H:   &h,
 			Pos: adcom1.PositionAboveFold.Ptr(),
-			API: []adcom1.APIFramework{adcom1.APIMRAID10, adcom1.APIMRAID20},
+			API: MRAIDAPI,
 		},
 	}
 }
 
 func (a *AdikteevAdapter) interstitial(auctionRequest *schema.AuctionRequest) *openrtb2.Imp {
-	size := adapters.FullscreenFormats[string(auctionRequest.Device.Type)]
+	size, found := adapters.FullscreenFormats[string(auctionRequest.Device.Type)]
+	if !found {
+		return nil
+	}
 	w, h := size[0], size[1]
 	if !auctionRequest.AdObject.IsPortrait() {
 		w, h = h, w
@@ -60,7 +67,7 @@ func (a *AdikteevAdapter) interstitial(auctionRequest *schema.AuctionRequest) *o
 			W:   &w,
 			H:   &h,
 			Pos: adcom1.PositionFullScreen.Ptr(),
-			API: []adcom1.APIFramework{adcom1.APIMRAID10, adcom1.APIMRAID20},
+			API: MRAIDAPI,
 		},
 		Video: &openrtb2.Video{
 			W:         w,
@@ -73,27 +80,7 @@ func (a *AdikteevAdapter) interstitial(auctionRequest *schema.AuctionRequest) *o
 }
 
 func (a *AdikteevAdapter) rewarded(auctionRequest *schema.AuctionRequest) *openrtb2.Imp {
-	size := adapters.FullscreenFormats[string(auctionRequest.Device.Type)]
-	w, h := size[0], size[1]
-	if !auctionRequest.AdObject.IsPortrait() {
-		w, h = h, w
-	}
-	return &openrtb2.Imp{
-		Instl: 1,
-		Banner: &openrtb2.Banner{
-			W:   &w,
-			H:   &h,
-			Pos: adcom1.PositionFullScreen.Ptr(),
-			API: []adcom1.APIFramework{adcom1.APIMRAID10, adcom1.APIMRAID20},
-		},
-		Video: &openrtb2.Video{
-			W:         w,
-			H:         h,
-			Pos:       adcom1.PositionFullScreen.Ptr(),
-			MIMEs:     []string{"video/mp4"},
-			Protocols: []adcom1.MediaCreativeSubtype{1, 2, 3, 4, 5, 6, 7, 8, 9, 10},
-		},
-	}
+	return a.interstitial(auctionRequest)
 }
 
 func (a *AdikteevAdapter) sdkInstanceID(auctionRequest *schema.AuctionRequest) []byte {

--- a/internal/bidding/adapters/adikteev/adikteev.go
+++ b/internal/bidding/adapters/adikteev/adikteev.go
@@ -1,0 +1,170 @@
+package adikteev
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"strconv"
+
+	"github.com/bidon-io/bidon-backend/internal/ad"
+	"github.com/bidon-io/bidon-backend/internal/adapter"
+	"github.com/bidon-io/bidon-backend/internal/bidding/adapters"
+	"github.com/bidon-io/bidon-backend/internal/bidding/openrtb"
+	"github.com/bidon-io/bidon-backend/internal/sdkapi/schema"
+	"github.com/gofrs/uuid/v5"
+	"github.com/prebid/openrtb/v19/openrtb2"
+)
+
+type AdikteevAdapter struct {
+	SellerID string
+	Endpoint string
+}
+
+var bannerFormats = map[ad.Format][2]int64{
+	ad.BannerFormat: {320, 480},
+}
+
+func (a *AdikteevAdapter) banner(auctionRequest *schema.AuctionRequest) *openrtb2.Imp {
+	size := bannerFormats[auctionRequest.AdObject.Format()]
+
+	w, h := size[0], size[1]
+
+	return &openrtb2.Imp{
+		Instl: 0,
+		Banner: &openrtb2.Banner{
+			W: &w,
+			H: &h,
+		},
+	}
+}
+
+func getEndpoint() string {
+	return "http://rubicon-eu.dsp.adikteev.com"
+}
+
+func (a *AdikteevAdapter) CreateRequest(request openrtb.BidRequest, auctionRequest *schema.AuctionRequest) (openrtb.BidRequest, error) {
+	secure := int8(1)
+
+	var imp *openrtb2.Imp
+	switch auctionRequest.AdObject.Type() {
+	case ad.BannerType:
+		imp = a.banner(auctionRequest)
+	default:
+		return request, errors.New("unknown impression type")
+	}
+
+	impId, _ := uuid.NewV4()
+	imp.ID = impId.String()
+	imp.DisplayManager = string(adapter.Adikteev)
+	imp.DisplayManagerVer = auctionRequest.Adapters[adapter.Adikteev].SDKVersion
+	imp.Secure = &secure
+	imp.BidFloor = adapters.CalculatePriceFloor(&request, auctionRequest)
+
+	request.App.Publisher.ID = a.SellerID
+
+	request.Imp = []openrtb2.Imp{*imp}
+	request.Cur = []string{"USD"}
+
+	return request, nil
+}
+
+func (a *AdikteevAdapter) ExecuteRequest(ctx context.Context, client *http.Client, request openrtb.BidRequest) *adapters.DemandResponse {
+	dr := &adapters.DemandResponse{
+		DemandID:  adapter.Adikteev,
+		RequestID: request.ID,
+	}
+	requestBody, err := json.Marshal(request)
+	if err != nil {
+		dr.Error = err
+		return dr
+	}
+	dr.RawRequest = string(requestBody)
+
+	url := getEndpoint()
+	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewBuffer(requestBody))
+	if err != nil {
+		dr.Error = err
+		return dr
+	}
+	httpReq.Header.Add("Content-Type", "application/json")
+
+	httpResp, err := client.Do(httpReq)
+	if err != nil {
+		dr.Error = err
+		return dr
+	}
+	defer httpResp.Body.Close()
+
+	respBody, err := io.ReadAll(httpResp.Body)
+	if err != nil {
+		dr.Error = err
+		return dr
+	}
+
+	dr.RawResponse = string(respBody)
+	dr.Status = httpResp.StatusCode
+
+	return dr
+}
+
+func (a *AdikteevAdapter) ParseBids(dr *adapters.DemandResponse) (*adapters.DemandResponse, error) {
+	switch dr.Status {
+	case http.StatusOK:
+		break
+	default:
+		return dr, fmt.Errorf("unexpected status code: %s", strconv.Itoa(dr.Status))
+	}
+
+	var bidResponse openrtb2.BidResponse
+	err := json.Unmarshal([]byte(dr.RawResponse), &bidResponse)
+	if err != nil {
+		return dr, err
+	}
+
+	seat := bidResponse.SeatBid[0]
+	bid := seat.Bid[0]
+
+	dr.Bid = &adapters.BidDemandResponse{
+		ID:       bid.ID,
+		ImpID:    bid.ImpID,
+		Price:    bid.Price,
+		Payload:  bid.AdM,
+		DemandID: adapter.Adikteev,
+		AdID:     bid.AdID,
+		SeatID:   seat.Seat,
+		LURL:     bid.LURL,
+		NURL:     bid.NURL,
+		BURL:     bid.BURL,
+	}
+
+	return dr, nil
+}
+
+// Builder builds a new instance of the Bidmachine adapter for the given bidder with the given config.
+func Builder(cfg adapter.ProcessedConfigsMap, client *http.Client) (*adapters.Bidder, error) {
+	bmCfg := cfg[adapter.Adikteev]
+	endpoint, ok := bmCfg["endpoint"].(string)
+	if !ok || endpoint == "" {
+		return nil, fmt.Errorf("missing endpoint param for Adikteev adapter")
+	}
+	sellerID, ok := bmCfg["seller_id"].(string)
+	if !ok || sellerID == "" {
+		return nil, fmt.Errorf("missing seller_id param for %s adapter", adapter.Adikteev)
+	}
+
+	adpt := &AdikteevAdapter{
+		Endpoint: endpoint,
+		SellerID: sellerID,
+	}
+
+	bidder := &adapters.Bidder{
+		Adapter: adpt,
+		Client:  client,
+	}
+
+	return bidder, nil
+}

--- a/internal/bidding/adapters/adikteev/adikteev.go
+++ b/internal/bidding/adapters/adikteev/adikteev.go
@@ -96,7 +96,7 @@ func (a *AdikteevAdapter) rewarded(auctionRequest *schema.AuctionRequest) *openr
 	}
 }
 
-func (a *AdikteevAdapter) sdkInstanceId(auctionRequest *schema.AuctionRequest) []byte {
+func (a *AdikteevAdapter) sdkInstanceID(auctionRequest *schema.AuctionRequest) []byte {
 	extStructure := map[string]interface{}{
 		"sdkinstanceid": auctionRequest.AdObject.Demands[adapter.AdikteevKey]["token"],
 	}
@@ -130,7 +130,7 @@ func (a *AdikteevAdapter) CreateRequest(request openrtb.BidRequest, auctionReque
 	imp.Secure = &secure
 	imp.BidFloor = adapters.CalculatePriceFloor(&request, auctionRequest)
 
-	request.App.Ext = a.sdkInstanceId(auctionRequest)
+	request.App.Ext = a.sdkInstanceID(auctionRequest)
 
 	request.Imp = []openrtb2.Imp{*imp}
 	request.Cur = []string{"USD"}

--- a/internal/bidding/adapters/adikteev/adikteev.go
+++ b/internal/bidding/adapters/adikteev/adikteev.go
@@ -21,9 +21,11 @@ import (
 )
 
 type AdikteevAdapter struct {
-	SellerID string
-	Endpoint string
 }
+
+//Loïc Anton: map sdk request ad types to ad formats
+//  banner => openrtb2.Banner with MRAID api
+//  interstitial and rewarded => openrtb2.banner with MRAID API + openrtb2.video
 
 var bannerFormats = map[ad.Format][2]int64{
 	ad.BannerFormat: {320, 50},
@@ -41,6 +43,7 @@ func (a *AdikteevAdapter) banner(auctionRequest *schema.AuctionRequest) *openrtb
 			W:   &w,
 			H:   &h,
 			Pos: adcom1.PositionAboveFold.Ptr(),
+			API: []adcom1.APIFramework{adcom1.APIMRAID10, adcom1.APIMRAID20},
 		},
 	}
 }
@@ -57,6 +60,14 @@ func (a *AdikteevAdapter) interstitial(auctionRequest *schema.AuctionRequest) *o
 			W:   &w,
 			H:   &h,
 			Pos: adcom1.PositionFullScreen.Ptr(),
+			API: []adcom1.APIFramework{adcom1.APIMRAID10, adcom1.APIMRAID20},
+		},
+		Video: &openrtb2.Video{
+			W:         w,
+			H:         h,
+			Pos:       adcom1.PositionFullScreen.Ptr(),
+			MIMEs:     []string{"video/mp4"},
+			Protocols: []adcom1.MediaCreativeSubtype{1, 2, 3, 4, 5, 6, 7, 8, 9, 10},
 		},
 	}
 }
@@ -69,23 +80,31 @@ func (a *AdikteevAdapter) rewarded(auctionRequest *schema.AuctionRequest) *openr
 	}
 	return &openrtb2.Imp{
 		Instl: 1,
-		//Banner: &openrtb2.Banner{
-		//	W:   &w,
-		//	H:   &h,
-		//	Pos: adcom1.PositionFullScreen.Ptr(),
-		//},
+		Banner: &openrtb2.Banner{
+			W:   &w,
+			H:   &h,
+			Pos: adcom1.PositionFullScreen.Ptr(),
+			API: []adcom1.APIFramework{adcom1.APIMRAID10, adcom1.APIMRAID20},
+		},
 		Video: &openrtb2.Video{
 			W:         w,
 			H:         h,
 			Pos:       adcom1.PositionFullScreen.Ptr(),
-			MIMEs:     []string{"video/mp4", "video/x-m4v", "video/quicktime", "video/mpeg", "video/avi"},
+			MIMEs:     []string{"video/mp4"},
 			Protocols: []adcom1.MediaCreativeSubtype{1, 2, 3, 4, 5, 6, 7, 8, 9, 10},
 		},
 	}
 }
 
+func (a *AdikteevAdapter) sdkInstanceId(auctionRequest *schema.AuctionRequest) []byte {
+	extStructure := map[string]interface{}{
+		"sdkinstanceid": auctionRequest.AdObject.Demands[adapter.AdikteevKey]["token"],
+	}
+	raw, _ := json.Marshal(extStructure)
+	return raw
+}
+
 func getEndpoint() string {
-	//return "http://rubicon-eu.dsp.adikteev.com"
 	return "http://appodeal-eu.dsp.adikteev.com" //?debug=true"
 }
 
@@ -106,12 +125,12 @@ func (a *AdikteevAdapter) CreateRequest(request openrtb.BidRequest, auctionReque
 
 	impId, _ := uuid.NewV4()
 	imp.ID = impId.String()
-	imp.DisplayManager = string(adapter.Adikteev)
-	imp.DisplayManagerVer = auctionRequest.Adapters[adapter.Adikteev].SDKVersion
+	imp.DisplayManager = string(adapter.AdikteevKey)
+	imp.DisplayManagerVer = auctionRequest.Adapters[adapter.AdikteevKey].SDKVersion
 	imp.Secure = &secure
 	imp.BidFloor = adapters.CalculatePriceFloor(&request, auctionRequest)
 
-	request.App.Publisher.ID = a.SellerID
+	request.App.Ext = a.sdkInstanceId(auctionRequest)
 
 	request.Imp = []openrtb2.Imp{*imp}
 	request.Cur = []string{"USD"}
@@ -121,7 +140,7 @@ func (a *AdikteevAdapter) CreateRequest(request openrtb.BidRequest, auctionReque
 
 func (a *AdikteevAdapter) ExecuteRequest(ctx context.Context, client *http.Client, request openrtb.BidRequest) *adapters.DemandResponse {
 	dr := &adapters.DemandResponse{
-		DemandID:  adapter.Adikteev,
+		DemandID:  adapter.AdikteevKey,
 		RequestID: request.ID,
 	}
 	requestBody, err := json.Marshal(request)
@@ -138,8 +157,6 @@ func (a *AdikteevAdapter) ExecuteRequest(ctx context.Context, client *http.Clien
 		return dr
 	}
 	httpReq.Header.Add("Content-Type", "application/json")
-
-	//filename := fmt.Sprintf("%s_%s_%s_bid_req", request.Device.OS, request.Imp[0].DisplayManager, )
 
 	httpResp, err := client.Do(httpReq)
 	if err != nil {
@@ -182,7 +199,7 @@ func (a *AdikteevAdapter) ParseBids(dr *adapters.DemandResponse) (*adapters.Dema
 		ImpID:    bid.ImpID,
 		Price:    bid.Price,
 		Payload:  bid.AdM,
-		DemandID: adapter.Adikteev,
+		DemandID: adapter.AdikteevKey,
 		AdID:     bid.AdID,
 		SeatID:   seat.Seat,
 		LURL:     bid.LURL,
@@ -195,20 +212,7 @@ func (a *AdikteevAdapter) ParseBids(dr *adapters.DemandResponse) (*adapters.Dema
 
 // Builder builds a new instance of the Bidmachine adapter for the given bidder with the given config.
 func Builder(cfg adapter.ProcessedConfigsMap, client *http.Client) (*adapters.Bidder, error) {
-	bmCfg := cfg[adapter.Adikteev]
-	endpoint, ok := bmCfg["endpoint"].(string)
-	if !ok || endpoint == "" {
-		return nil, fmt.Errorf("missing endpoint param for Adikteev adapter")
-	}
-	sellerID, ok := bmCfg["seller_id"].(string)
-	if !ok || sellerID == "" {
-		return nil, fmt.Errorf("missing seller_id param for %s adapter", adapter.Adikteev)
-	}
-
-	adpt := &AdikteevAdapter{
-		Endpoint: endpoint,
-		SellerID: sellerID,
-	}
+	adpt := &AdikteevAdapter{}
 
 	bidder := &adapters.Bidder{
 		Adapter: adpt,

--- a/internal/bidding/adapters/adikteev/adikteev.go
+++ b/internal/bidding/adapters/adikteev/adikteev.go
@@ -61,6 +61,29 @@ func (a *AdikteevAdapter) interstitial(auctionRequest *schema.AuctionRequest) *o
 	}
 }
 
+func (a *AdikteevAdapter) rewarded(auctionRequest *schema.AuctionRequest) *openrtb2.Imp {
+	size := adapters.FullscreenFormats[string(auctionRequest.Device.Type)]
+	w, h := size[0], size[1]
+	if !auctionRequest.AdObject.IsPortrait() {
+		w, h = h, w
+	}
+	return &openrtb2.Imp{
+		Instl: 1,
+		//Banner: &openrtb2.Banner{
+		//	W:   &w,
+		//	H:   &h,
+		//	Pos: adcom1.PositionFullScreen.Ptr(),
+		//},
+		Video: &openrtb2.Video{
+			W:         w,
+			H:         h,
+			Pos:       adcom1.PositionFullScreen.Ptr(),
+			MIMEs:     []string{"video/mp4", "video/x-m4v", "video/quicktime", "video/mpeg", "video/avi"},
+			Protocols: []adcom1.MediaCreativeSubtype{1, 2, 3, 4, 5, 6, 7, 8, 9, 10},
+		},
+	}
+}
+
 func getEndpoint() string {
 	//return "http://rubicon-eu.dsp.adikteev.com"
 	return "http://appodeal-eu.dsp.adikteev.com" //?debug=true"
@@ -75,6 +98,8 @@ func (a *AdikteevAdapter) CreateRequest(request openrtb.BidRequest, auctionReque
 		imp = a.banner(auctionRequest)
 	case ad.InterstitialType:
 		imp = a.interstitial(auctionRequest)
+	case ad.RewardedType:
+		imp = a.rewarded(auctionRequest)
 	default:
 		return request, errors.New("unknown impression type")
 	}
@@ -113,6 +138,8 @@ func (a *AdikteevAdapter) ExecuteRequest(ctx context.Context, client *http.Clien
 		return dr
 	}
 	httpReq.Header.Add("Content-Type", "application/json")
+
+	//filename := fmt.Sprintf("%s_%s_%s_bid_req", request.Device.OS, request.Imp[0].DisplayManager, )
 
 	httpResp, err := client.Do(httpReq)
 	if err != nil {

--- a/internal/bidding/adapters/adikteev/adikteev.go
+++ b/internal/bidding/adapters/adikteev/adikteev.go
@@ -16,6 +16,7 @@ import (
 	"github.com/bidon-io/bidon-backend/internal/bidding/openrtb"
 	"github.com/bidon-io/bidon-backend/internal/sdkapi/schema"
 	"github.com/gofrs/uuid/v5"
+	"github.com/prebid/openrtb/v19/adcom1"
 	"github.com/prebid/openrtb/v19/openrtb2"
 )
 
@@ -25,7 +26,8 @@ type AdikteevAdapter struct {
 }
 
 var bannerFormats = map[ad.Format][2]int64{
-	ad.BannerFormat: {320, 480},
+	ad.BannerFormat: {320, 50},
+	ad.MRECFormat:   {300, 250},
 }
 
 func (a *AdikteevAdapter) banner(auctionRequest *schema.AuctionRequest) *openrtb2.Imp {
@@ -36,14 +38,32 @@ func (a *AdikteevAdapter) banner(auctionRequest *schema.AuctionRequest) *openrtb
 	return &openrtb2.Imp{
 		Instl: 0,
 		Banner: &openrtb2.Banner{
-			W: &w,
-			H: &h,
+			W:   &w,
+			H:   &h,
+			Pos: adcom1.PositionAboveFold.Ptr(),
+		},
+	}
+}
+
+func (a *AdikteevAdapter) interstitial(auctionRequest *schema.AuctionRequest) *openrtb2.Imp {
+	size := adapters.FullscreenFormats[string(auctionRequest.Device.Type)]
+	w, h := size[0], size[1]
+	if !auctionRequest.AdObject.IsPortrait() {
+		w, h = h, w
+	}
+	return &openrtb2.Imp{
+		Instl: 1, //they don't check the instl field to interpret the ad format, but only look at w and h
+		Banner: &openrtb2.Banner{
+			W:   &w,
+			H:   &h,
+			Pos: adcom1.PositionFullScreen.Ptr(),
 		},
 	}
 }
 
 func getEndpoint() string {
-	return "http://rubicon-eu.dsp.adikteev.com"
+	//return "http://rubicon-eu.dsp.adikteev.com"
+	return "http://appodeal-eu.dsp.adikteev.com" //?debug=true"
 }
 
 func (a *AdikteevAdapter) CreateRequest(request openrtb.BidRequest, auctionRequest *schema.AuctionRequest) (openrtb.BidRequest, error) {
@@ -53,6 +73,8 @@ func (a *AdikteevAdapter) CreateRequest(request openrtb.BidRequest, auctionReque
 	switch auctionRequest.AdObject.Type() {
 	case ad.BannerType:
 		imp = a.banner(auctionRequest)
+	case ad.InterstitialType:
+		imp = a.interstitial(auctionRequest)
 	default:
 		return request, errors.New("unknown impression type")
 	}

--- a/internal/bidding/adapters/adikteev/adikteev_test.go
+++ b/internal/bidding/adapters/adikteev/adikteev_test.go
@@ -9,7 +9,6 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/bidon-io/bidon-backend/internal/bidding/adapters/adikteev"
 	"github.com/google/go-cmp/cmp"
 	"github.com/prebid/openrtb/v19/adcom1"
 	"github.com/prebid/openrtb/v19/openrtb2"
@@ -17,6 +16,7 @@ import (
 	"github.com/bidon-io/bidon-backend/internal/ad"
 	"github.com/bidon-io/bidon-backend/internal/adapter"
 	"github.com/bidon-io/bidon-backend/internal/bidding/adapters"
+	"github.com/bidon-io/bidon-backend/internal/bidding/adapters/adikteev"
 	"github.com/bidon-io/bidon-backend/internal/bidding/openrtb"
 	"github.com/bidon-io/bidon-backend/internal/device"
 	"github.com/bidon-io/bidon-backend/internal/sdkapi/schema"

--- a/internal/bidding/adapters/adikteev/adikteev_test.go
+++ b/internal/bidding/adapters/adikteev/adikteev_test.go
@@ -1,0 +1,444 @@
+package adikteev_test
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"net/http"
+	"testing"
+
+	"github.com/bidon-io/bidon-backend/internal/bidding/adapters/adikteev"
+	"github.com/google/go-cmp/cmp"
+	"github.com/prebid/openrtb/v19/adcom1"
+	"github.com/prebid/openrtb/v19/openrtb2"
+
+	"github.com/bidon-io/bidon-backend/internal/ad"
+	"github.com/bidon-io/bidon-backend/internal/adapter"
+	"github.com/bidon-io/bidon-backend/internal/bidding/adapters"
+	"github.com/bidon-io/bidon-backend/internal/bidding/openrtb"
+	"github.com/bidon-io/bidon-backend/internal/device"
+	"github.com/bidon-io/bidon-backend/internal/sdkapi/schema"
+)
+
+type createRequestTestParams struct {
+	BaseBidRequest openrtb.BidRequest
+	AuctionRequest *schema.AuctionRequest
+}
+
+type createRequestTestOutput struct {
+	Request openrtb.BidRequest
+	Err     error
+}
+
+type ParseBidsTestParams struct {
+	DemandsResponse adapters.DemandResponse
+}
+
+type ParseBidsTestOutput struct {
+	DemandResponse adapters.DemandResponse
+	Err            error
+}
+
+type TestTransport func(req *http.Request) *http.Response
+
+func (f TestTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	return f(req), nil
+}
+
+func NewTestClient(tr TestTransport) *http.Client {
+	return &http.Client{
+		Transport: tr,
+	}
+}
+
+func ptr[T any](t T) *T {
+	return &t
+}
+
+// compareErrors checks for error occurrence.
+func compareErrors(want, got error) bool {
+	return (want == nil) == (got == nil)
+}
+
+func buildAdapter() adikteev.AdikteevAdapter {
+	return adikteev.AdikteevAdapter{}
+}
+
+func buildBaseRequest() openrtb.BidRequest {
+	return openrtb.BidRequest{
+		App: &openrtb2.App{},
+	}
+}
+
+func buildTestParams(imp schema.AdObject) createRequestTestParams {
+	request := buildBaseRequest()
+
+	auctionRequest := schema.AuctionRequest{
+		Adapters: schema.Adapters{
+			"adikteev": schema.Adapter{
+				Version:    "1.0.0",
+				SDKVersion: "1.0.0",
+			},
+		},
+		AdObject: schema.AdObject{
+			Demands: map[adapter.Key]map[string]any{
+				adapter.AdikteevKey: {
+					"token": "sdk_instance_id",
+				},
+			},
+			Orientation: "PORTRAIT",
+		},
+		BaseRequest: schema.BaseRequest{
+			App: schema.App{
+				SDKVersion: "1.0.0",
+			},
+			Device: schema.Device{
+				Type: device.PhoneType,
+			},
+		},
+	}
+
+	if imp.Banner != nil {
+		auctionRequest.AdObject.Banner = imp.Banner
+	}
+	if imp.Interstitial != nil {
+		auctionRequest.AdObject.Interstitial = imp.Interstitial
+	}
+	if imp.Rewarded != nil {
+		auctionRequest.AdObject.Rewarded = imp.Rewarded
+	}
+
+	return createRequestTestParams{
+		BaseBidRequest: request,
+		AuctionRequest: &auctionRequest,
+	}
+}
+
+func buildWantRequest(imp openrtb2.Imp) openrtb.BidRequest {
+	request := openrtb.BidRequest{
+		App: &openrtb2.App{
+			Ext: json.RawMessage(`{"sdkinstanceid":"sdk_instance_id"}`),
+		},
+		User: nil,
+		Cur:  []string{"USD"},
+		Imp: []openrtb2.Imp{
+			{
+				ID:                "1",
+				DisplayManager:    "adikteev",
+				DisplayManagerVer: "1.0.0",
+				TagID:             "",
+				Secure:            ptr(int8(1)),
+				BidFloor:          schema.MinBidFloor,
+			},
+		},
+	}
+	if imp.Banner != nil {
+		request.Imp[0].Banner = imp.Banner
+	}
+	if imp.Video != nil {
+		request.Imp[0].Video = imp.Video
+	}
+	if imp.Instl != 0 {
+		request.Imp[0].Instl = imp.Instl
+	}
+	if imp.Ext != nil {
+		request.Imp[0].Ext = imp.Ext
+	}
+
+	return request
+}
+
+func TestAdikteev_CreateRequest(t *testing.T) {
+	testCases := []struct {
+		name   string
+		params createRequestTestParams
+		want   createRequestTestOutput
+	}{
+		{
+			name: "Banner MREC",
+			params: buildTestParams(
+				schema.AdObject{
+					Banner: &schema.BannerAdObject{
+						Format: ad.MRECFormat,
+					},
+				},
+			),
+			want: createRequestTestOutput{
+				Request: buildWantRequest(openrtb2.Imp{
+					Instl: 0,
+					Banner: &openrtb2.Banner{
+						W:   ptr(int64(300)),
+						H:   ptr(int64(250)),
+						Pos: adcom1.PositionAboveFold.Ptr(),
+						API: []adcom1.APIFramework{3, 5},
+					},
+				}),
+				Err: nil,
+			},
+		},
+		{
+			name: "Banner BANNER",
+			params: buildTestParams(
+				schema.AdObject{
+					Banner: &schema.BannerAdObject{
+						Format: ad.BannerFormat,
+					},
+				},
+			),
+			want: createRequestTestOutput{
+				Request: buildWantRequest(openrtb2.Imp{
+					Instl: 0,
+					Banner: &openrtb2.Banner{
+						W:   ptr(int64(320)),
+						H:   ptr(int64(50)),
+						Pos: adcom1.PositionAboveFold.Ptr(),
+						API: []adcom1.APIFramework{3, 5},
+					},
+				}),
+				Err: nil,
+			},
+		},
+		{
+			name: "Interstitial",
+			params: buildTestParams(
+				schema.AdObject{
+					Interstitial: &schema.InterstitialAdObject{},
+				},
+			),
+			want: createRequestTestOutput{
+				Request: buildWantRequest(openrtb2.Imp{
+					Instl: 1,
+					Banner: &openrtb2.Banner{
+						W:   ptr(int64(320)),
+						H:   ptr(int64(480)),
+						Pos: adcom1.PositionFullScreen.Ptr(),
+						API: []adcom1.APIFramework{3, 5},
+					},
+					Video: &openrtb2.Video{
+						W:         int64(320),
+						H:         int64(480),
+						Pos:       adcom1.PositionFullScreen.Ptr(),
+						MIMEs:     []string{"video/mp4"},
+						Protocols: []adcom1.MediaCreativeSubtype{1, 2, 3, 4, 5, 6, 7, 8, 9, 10},
+					},
+				}),
+				Err: nil,
+			},
+		},
+		{
+			name: "Rewarded",
+			params: buildTestParams(
+				schema.AdObject{
+					Rewarded: &schema.RewardedAdObject{},
+				},
+			),
+			want: createRequestTestOutput{
+				Request: buildWantRequest(openrtb2.Imp{
+					Instl: 1,
+					Banner: &openrtb2.Banner{
+						W:   ptr(int64(320)),
+						H:   ptr(int64(480)),
+						Pos: adcom1.PositionFullScreen.Ptr(),
+						API: []adcom1.APIFramework{3, 5},
+					},
+					Video: &openrtb2.Video{
+						MIMEs:     []string{"video/mp4"},
+						W:         320,
+						H:         480,
+						Pos:       adcom1.PositionFullScreen.Ptr(),
+						Protocols: []adcom1.MediaCreativeSubtype{1, 2, 3, 4, 5, 6, 7, 8, 9, 10},
+					},
+				}),
+				Err: nil,
+			},
+		},
+	}
+
+	adapter := buildAdapter()
+	for _, tC := range testCases {
+		request, err := adapter.CreateRequest(tC.params.BaseBidRequest, tC.params.AuctionRequest)
+		if err == nil {
+			request.Imp[0].ID = "1" // ommit random uuid
+		}
+		got := createRequestTestOutput{
+			Request: request,
+			Err:     err,
+		}
+		if diff := cmp.Diff(tC.want, got, cmp.Comparer(compareErrors)); diff != "" {
+			t.Errorf("%s: adapter.CreateRequest(ctx, %v, %v) mismatch (-want, +got):\n%s", tC.name, tC.params.BaseBidRequest, tC.params.AuctionRequest, diff)
+		}
+	}
+}
+
+func TestAdikteevAdapter_ExecuteRequest(t *testing.T) {
+	networkAdapter := buildAdapter()
+	responseBody := []byte(`{"key": "value"`)
+
+	customClient := NewTestClient(func(req *http.Request) *http.Response {
+		if req.Method != http.MethodPost {
+			t.Errorf("Expected POST request")
+		}
+		if req.URL.String() != "http://appodeal-eu.dsp.adikteev.com" {
+			t.Errorf("Expected URL: http://appodeal-eu.dsp.adikteev.com")
+		}
+		contentType := req.Header.Get("Content-Type")
+		if contentType != "application/json" {
+			t.Errorf("Expected Content-Type header: application/json")
+		}
+		return &http.Response{
+			Status:        http.StatusText(http.StatusOK),
+			StatusCode:    http.StatusOK,
+			Body:          io.NopCloser(bytes.NewBuffer(responseBody)),
+			ContentLength: int64(len(responseBody)),
+		}
+	})
+	request := openrtb.BidRequest{
+		ID: "test-request-id",
+	}
+
+	response := networkAdapter.ExecuteRequest(context.Background(), customClient, request)
+
+	if response.DemandID != adapter.AdikteevKey {
+		t.Errorf("Expected DemandID %v, but got %v", adapter.AdikteevKey, response.DemandID)
+	}
+	if response.RequestID != request.ID {
+		t.Errorf("Expected RequestID %v, but got %v", request.ID, response.RequestID)
+	}
+	if response.TagID != "" {
+		t.Errorf("Expected TagID be blank, but got %v", response.TagID)
+	}
+	if response.PlacementID != "" {
+		t.Errorf("Expected PlacementID be blank, but got %v", response.PlacementID)
+	}
+	if response.Error != nil {
+		t.Errorf("Expected no error, but got an error: %v", response.Error)
+	}
+	if response.RawResponse != string(responseBody) {
+		t.Errorf("Expected client response body as RawResponse but got: %v", response.RawResponse)
+	}
+	if response.Status != http.StatusOK {
+		t.Errorf("Expected status code %d, but got %d", http.StatusOK, response.Status)
+	}
+}
+
+func TestAdikteev_ParseBids(t *testing.T) {
+	rawResponse := `{
+		"id": "47611e59-e05b-4e1e-9074-5a65eb4501e4",
+		"seatbid": [
+			{
+				"bid": [
+					{
+						"id": "0",
+						"impid": "6579ca7b-7e2c-48b6-8915-46efa6530fb5",
+						"price": 1.5,
+						"nurl": "https://api.gov-static.tech/Ad/AdxEvent?sid=0&sslot=10182906-10163778&adtype=4",
+						"lurl": "https://api.gov-static.tech/Ad/AdxEvent?sid=0&sslot=10182906-10163778",
+						"adm": "0692d0a0efdbd5bd470dafea742cef6a1f6b840c5c83240e165bc33a038b3d5487e25a52",
+						"adid": "bmad5e0471131b8a4e3c",
+						"crid": "e2d42134881d5b45134f3cf77989dec7"
+					}
+				]
+			}
+		]
+	}`
+	adapter := buildAdapter()
+
+	testCases := []struct {
+		name   string
+		params ParseBidsTestParams
+		want   ParseBidsTestOutput
+	}{
+		{
+			name: "ParseBids Success",
+			params: ParseBidsTestParams{
+				DemandsResponse: adapters.DemandResponse{
+					Status:      200,
+					RawResponse: rawResponse,
+				},
+			},
+			want: ParseBidsTestOutput{
+				DemandResponse: adapters.DemandResponse{
+					Status:      200,
+					RawResponse: rawResponse,
+					Bid: &adapters.BidDemandResponse{
+						ID:       "0",
+						ImpID:    "6579ca7b-7e2c-48b6-8915-46efa6530fb5",
+						Price:    1.5,
+						Payload:  "0692d0a0efdbd5bd470dafea742cef6a1f6b840c5c83240e165bc33a038b3d5487e25a52",
+						DemandID: "adikteev",
+						AdID:     "bmad5e0471131b8a4e3c",
+						LURL:     "https://api.gov-static.tech/Ad/AdxEvent?sid=0&sslot=10182906-10163778",
+						NURL:     "https://api.gov-static.tech/Ad/AdxEvent?sid=0&sslot=10182906-10163778&adtype=4",
+					},
+				},
+				Err: nil,
+			},
+		},
+		{
+			name: "ParseBids Bad Request",
+			params: ParseBidsTestParams{
+				DemandsResponse: adapters.DemandResponse{
+					Status:      400,
+					RawResponse: rawResponse,
+				},
+			},
+			want: ParseBidsTestOutput{
+				DemandResponse: adapters.DemandResponse{
+					Status:      400,
+					RawResponse: rawResponse,
+				},
+				Err: errors.New("unauthorized request: 400"),
+			},
+		},
+		{
+			name: "ParseBids No Content",
+			params: ParseBidsTestParams{
+				DemandsResponse: adapters.DemandResponse{
+					Status:      204,
+					RawResponse: rawResponse,
+				},
+			},
+			want: ParseBidsTestOutput{
+				DemandResponse: adapters.DemandResponse{
+					Status:      204,
+					RawResponse: rawResponse,
+				},
+				Err: nil,
+			},
+		},
+	}
+	for _, tC := range testCases {
+		response, err := adapter.ParseBids(&tC.params.DemandsResponse)
+		got := ParseBidsTestOutput{
+			DemandResponse: *response,
+			Err:            err,
+		}
+		if diff := cmp.Diff(tC.want, got, cmp.Comparer(compareErrors)); diff != "" {
+			t.Errorf("%s: adapter.ParseBids(ctx, %v) mismatch (-want, +got):\n%s", tC.name, tC.params.DemandsResponse, diff)
+		}
+	}
+}
+
+func TestAdikteev_Builder(t *testing.T) {
+	client := &http.Client{}
+	bmCfg := adapter.ProcessedConfigsMap{
+		adapter.AdikteevKey: map[string]any{
+			"seller_id": "1",
+			"endpoint":  "example.com",
+		},
+	}
+	bidder, err := adikteev.Builder(bmCfg, client)
+	wantAdapter := buildAdapter()
+	wantBidder := &adapters.Bidder{
+		Adapter: &wantAdapter,
+		Client:  client,
+	}
+	if err != nil {
+		t.Errorf("Error building adapter: %v", err)
+	}
+	if diff := cmp.Diff(wantBidder, bidder); diff != "" {
+		t.Errorf("builder(bmCfg, client) mismatch (-want, +got):\n%s", diff)
+	}
+}

--- a/internal/bidding/adapters_builder/adapters_builder.go
+++ b/internal/bidding/adapters_builder/adapters_builder.go
@@ -27,7 +27,7 @@ import (
 )
 
 var biddingAdapters = map[adapter.Key]adapters.Builder{
-	adapter.Adikteev:      adikteev.Builder,
+	adapter.AdikteevKey:   adikteev.Builder,
 	adapter.BidmachineKey: bidmachine.Builder,
 	adapter.BigoAdsKey:    bigoads.Builder,
 	adapter.InmobiKey:     inmobi.Builder,
@@ -108,9 +108,8 @@ func (b *AdaptersConfigBuilder) Build(ctx context.Context, appID int64, adapterK
 		extra := profile.AccountExtra
 		appData := profile.AppData
 		switch key {
-		case adapter.Adikteev:
-			adaptersMap[key]["seller_id"] = extra["seller_id"]
-			adaptersMap[key]["endpoint"] = extra["endpoint"]
+		case adapter.AdikteevKey:
+			adaptersMap[key]["sdk_instance_id"] = extra["sdk_instance_id"]
 		case adapter.AmazonKey:
 			adaptersMap[key]["price_points_map"] = extra["price_points_map"]
 		case adapter.BidmachineKey:

--- a/internal/bidding/adapters_builder/adapters_builder.go
+++ b/internal/bidding/adapters_builder/adapters_builder.go
@@ -9,6 +9,7 @@ import (
 	"github.com/bidon-io/bidon-backend/internal/adapter"
 	"github.com/bidon-io/bidon-backend/internal/auction"
 	"github.com/bidon-io/bidon-backend/internal/bidding/adapters"
+	"github.com/bidon-io/bidon-backend/internal/bidding/adapters/adikteev"
 	"github.com/bidon-io/bidon-backend/internal/bidding/adapters/bidmachine"
 	"github.com/bidon-io/bidon-backend/internal/bidding/adapters/bigoads"
 	"github.com/bidon-io/bidon-backend/internal/bidding/adapters/inmobi"
@@ -26,6 +27,7 @@ import (
 )
 
 var biddingAdapters = map[adapter.Key]adapters.Builder{
+	adapter.Adikteev:      adikteev.Builder,
 	adapter.BidmachineKey: bidmachine.Builder,
 	adapter.BigoAdsKey:    bigoads.Builder,
 	adapter.InmobiKey:     inmobi.Builder,
@@ -106,6 +108,9 @@ func (b *AdaptersConfigBuilder) Build(ctx context.Context, appID int64, adapterK
 		extra := profile.AccountExtra
 		appData := profile.AppData
 		switch key {
+		case adapter.Adikteev:
+			adaptersMap[key]["seller_id"] = extra["seller_id"]
+			adaptersMap[key]["endpoint"] = extra["endpoint"]
 		case adapter.AmazonKey:
 			adaptersMap[key]["price_points_map"] = extra["price_points_map"]
 		case adapter.BidmachineKey:

--- a/internal/db/dbtest/app_demand_profile_factory.go
+++ b/internal/db/dbtest/app_demand_profile_factory.go
@@ -67,6 +67,8 @@ func ValidAppDemandProfileData(t *testing.T, key adapter.Key, appID int64) []byt
 	t.Helper()
 
 	switch key {
+	case adapter.Adikteev:
+		return []byte(`{"foo": "bar"}`)
 	case adapter.AdmobKey:
 		return []byte(fmt.Sprintf(`{"app_id": "admob_app_%d", "foo": "bar"}`, appID))
 	case adapter.ApplovinKey:

--- a/internal/db/dbtest/app_demand_profile_factory.go
+++ b/internal/db/dbtest/app_demand_profile_factory.go
@@ -67,8 +67,8 @@ func ValidAppDemandProfileData(t *testing.T, key adapter.Key, appID int64) []byt
 	t.Helper()
 
 	switch key {
-	case adapter.Adikteev:
-		return []byte(`{"foo": "bar"}`)
+	case adapter.AdikteevKey:
+		return []byte(`{"sdk_instance_id": "sdk_instance_id"}`)
 	case adapter.AdmobKey:
 		return []byte(fmt.Sprintf(`{"app_id": "admob_app_%d", "foo": "bar"}`, appID))
 	case adapter.ApplovinKey:

--- a/internal/db/dbtest/demand_source_account_factory.go
+++ b/internal/db/dbtest/demand_source_account_factory.go
@@ -76,8 +76,8 @@ func ValidDemandSourceAccountExtra(t *testing.T, key adapter.Key) []byte {
 	t.Helper()
 
 	switch key {
-	case adapter.Adikteev:
-		return []byte(`{"seller_id": "1", "endpoint": "rubicon-eu.dsp.adikteev.com"}`)
+	case adapter.AdikteevKey:
+		return []byte(`{}`)
 	case adapter.AdmobKey:
 		return []byte(`{"foo": "bar"}`)
 	case adapter.ApplovinKey:

--- a/internal/db/dbtest/demand_source_account_factory.go
+++ b/internal/db/dbtest/demand_source_account_factory.go
@@ -76,6 +76,8 @@ func ValidDemandSourceAccountExtra(t *testing.T, key adapter.Key) []byte {
 	t.Helper()
 
 	switch key {
+	case adapter.Adikteev:
+		return []byte(`{"seller_id": "1", "endpoint": "rubicon-eu.dsp.adikteev.com"}`)
 	case adapter.AdmobKey:
 		return []byte(`{"foo": "bar"}`)
 	case adapter.ApplovinKey:

--- a/internal/sdkapi/adapter_init_config.go
+++ b/internal/sdkapi/adapter_init_config.go
@@ -77,7 +77,7 @@ func NewAdapterInitConfig(key adapter.Key, setOrder bool) (AdapterInitConfig, er
 }
 
 type AdkiteevInitConfig struct {
-	SdkInstanceId string `json:"sdk_instance_id"`
+	SdkInstanceID string `json:"sdk_instance_id"`
 	Order         int    `json:"order"`
 }
 

--- a/internal/sdkapi/adapter_init_config.go
+++ b/internal/sdkapi/adapter_init_config.go
@@ -14,6 +14,8 @@ type AdapterInitConfig interface {
 func NewAdapterInitConfig(key adapter.Key, setOrder bool) (AdapterInitConfig, error) {
 	var config AdapterInitConfig
 	switch key {
+	case adapter.Adikteev:
+		config = new(AdkiteevInitConfig)
 	case adapter.AdmobKey:
 		config = new(AdmobInitConfig)
 	case adapter.ApplovinKey:
@@ -72,6 +74,18 @@ func NewAdapterInitConfig(key adapter.Key, setOrder bool) (AdapterInitConfig, er
 	}
 
 	return config, nil
+}
+
+type AdkiteevInitConfig struct {
+	Order int `json:"order"`
+}
+
+func (a *AdkiteevInitConfig) Key() adapter.Key {
+	return adapter.Adikteev
+}
+
+func (a *AdkiteevInitConfig) SetDefaultOrder() {
+	a.Order = 1
 }
 
 type AdmobInitConfig struct {

--- a/internal/sdkapi/adapter_init_config.go
+++ b/internal/sdkapi/adapter_init_config.go
@@ -14,7 +14,7 @@ type AdapterInitConfig interface {
 func NewAdapterInitConfig(key adapter.Key, setOrder bool) (AdapterInitConfig, error) {
 	var config AdapterInitConfig
 	switch key {
-	case adapter.Adikteev:
+	case adapter.AdikteevKey:
 		config = new(AdkiteevInitConfig)
 	case adapter.AdmobKey:
 		config = new(AdmobInitConfig)
@@ -77,15 +77,16 @@ func NewAdapterInitConfig(key adapter.Key, setOrder bool) (AdapterInitConfig, er
 }
 
 type AdkiteevInitConfig struct {
-	Order int `json:"order"`
+	SdkInstanceId string `json:"sdk_instance_id"`
+	Order         int    `json:"order"`
 }
 
 func (a *AdkiteevInitConfig) Key() adapter.Key {
-	return adapter.Adikteev
+	return adapter.AdikteevKey
 }
 
 func (a *AdkiteevInitConfig) SetDefaultOrder() {
-	a.Order = 1
+	a.Order = 0
 }
 
 type AdmobInitConfig struct {

--- a/internal/sdkapi/store/store_test.go
+++ b/internal/sdkapi/store/store_test.go
@@ -201,7 +201,7 @@ func TestAdapterInitConfigsFetcher_FetchAdapterInitConfigs_Valid(t *testing.T) {
 			setOrder:       false,
 			want: []sdkapi.AdapterInitConfig{
 				&sdkapi.AdkiteevInitConfig{
-					SdkInstanceId: "sdk_instance_id",
+					SdkInstanceID: "sdk_instance_id",
 					Order:         0,
 				},
 				&sdkapi.ChartboostInitConfig{
@@ -259,7 +259,7 @@ func TestAdapterInitConfigsFetcher_FetchAdapterInitConfigs_Valid(t *testing.T) {
 			setAmazonSlots: true,
 			setOrder:       true,
 			want: []sdkapi.AdapterInitConfig{
-				&sdkapi.AdkiteevInitConfig{SdkInstanceId: "sdk_instance_id"},
+				&sdkapi.AdkiteevInitConfig{SdkInstanceID: "sdk_instance_id"},
 				&sdkapi.ChartboostInitConfig{
 					AppID:        fmt.Sprintf("chartboost_app_%d", apps[1].ID),
 					AppSignature: "123",

--- a/internal/sdkapi/store/store_test.go
+++ b/internal/sdkapi/store/store_test.go
@@ -200,7 +200,10 @@ func TestAdapterInitConfigsFetcher_FetchAdapterInitConfigs_Valid(t *testing.T) {
 			setAmazonSlots: true,
 			setOrder:       false,
 			want: []sdkapi.AdapterInitConfig{
-				&sdkapi.AdkiteevInitConfig{},
+				&sdkapi.AdkiteevInitConfig{
+					SdkInstanceId: "sdk_instance_id",
+					Order:         0,
+				},
 				&sdkapi.ChartboostInitConfig{
 					AppID:        fmt.Sprintf("chartboost_app_%d", apps[1].ID),
 					AppSignature: "123",
@@ -256,7 +259,7 @@ func TestAdapterInitConfigsFetcher_FetchAdapterInitConfigs_Valid(t *testing.T) {
 			setAmazonSlots: true,
 			setOrder:       true,
 			want: []sdkapi.AdapterInitConfig{
-				&sdkapi.AdkiteevInitConfig{Order: 1},
+				&sdkapi.AdkiteevInitConfig{SdkInstanceId: "sdk_instance_id"},
 				&sdkapi.ChartboostInitConfig{
 					AppID:        fmt.Sprintf("chartboost_app_%d", apps[1].ID),
 					AppSignature: "123",

--- a/internal/sdkapi/store/store_test.go
+++ b/internal/sdkapi/store/store_test.go
@@ -200,6 +200,7 @@ func TestAdapterInitConfigsFetcher_FetchAdapterInitConfigs_Valid(t *testing.T) {
 			setAmazonSlots: true,
 			setOrder:       false,
 			want: []sdkapi.AdapterInitConfig{
+				&sdkapi.AdkiteevInitConfig{},
 				&sdkapi.ChartboostInitConfig{
 					AppID:        fmt.Sprintf("chartboost_app_%d", apps[1].ID),
 					AppSignature: "123",
@@ -255,6 +256,7 @@ func TestAdapterInitConfigsFetcher_FetchAdapterInitConfigs_Valid(t *testing.T) {
 			setAmazonSlots: true,
 			setOrder:       true,
 			want: []sdkapi.AdapterInitConfig{
+				&sdkapi.AdkiteevInitConfig{Order: 1},
 				&sdkapi.ChartboostInitConfig{
 					AppID:        fmt.Sprintf("chartboost_app_%d", apps[1].ID),
 					AppSignature: "123",

--- a/internal/sdkapi/v2/apihandlers/testdata/auction/adikteev/android_adikteev_banner.json
+++ b/internal/sdkapi/v2/apihandlers/testdata/auction/adikteev/android_adikteev_banner.json
@@ -63,7 +63,7 @@
     "auction_pricefloor": 0.001,
     "demands": {
       "adikteev": {
-        "token": "token-is-needed"
+        "token": "sdk-instance-id"
       }
     },
     "id": "f2d0dc19-b43f-43c1-8ca0-ae895ec76970",

--- a/internal/sdkapi/v2/apihandlers/testdata/auction/adikteev/android_adikteev_banner.json
+++ b/internal/sdkapi/v2/apihandlers/testdata/auction/adikteev/android_adikteev_banner.json
@@ -1,0 +1,75 @@
+{
+  "adapters": {
+    "adikteev": {
+      "version": "1",
+      "sdk_version": "11.8.2"
+    }
+  },
+  "device": {
+    "connection_type": "WIFI",
+    "model": "Google Pixel 3",
+    "hwv": "blueline",
+    "h": 2028,
+    "js": 1,
+    "language": "en_US",
+    "make": "Google",
+    "os": "android",
+    "osv": "12",
+    "ppi": 440,
+    "pxratio": 3.0,
+    "type": "PHONE",
+    "ua": "Mozilla/5.0 (Linux; Android 12; Pixel 3 Build/SP1A.210812.016.C1; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/114.0.5735.131 Mobile Safari/537.36",
+    "w": 1080
+  },
+  "app": {
+    "bundle": "com.demo.tetris",
+    "key": "tetris_2005",
+    "framework": "native",
+    "version": "1.0"
+  },
+  "token": "{}",
+  "session": {
+    "battery": 100,
+    "cpu_usage": 0.7714286,
+    "id": "d0b9ec0e-60e9-4501-bcbc-67712562dab9",
+    "launch_monotonic_ts": 68406545,
+    "launch_ts": 1687863971253,
+    "memory_warnings_monotonic_ts": [],
+    "memory_warnings_ts": [],
+    "start_monotonic_ts": 68406545,
+    "monotonic_ts": 68471084,
+    "ram_size": 3753299968,
+    "ram_used": 413565952,
+    "start_ts": 1687863971253,
+    "storage_free": 30742986752,
+    "storage_used": 24636485632,
+    "ts": 1687864035792
+  },
+  "user": {
+    "idg": "8020a0a6-5e55-4b8f-af9a-7b01a9aad4fc",
+    "coppa": false,
+    "idfa": "013b8c47-8beb-41b4-aefe-60fe466f9fd8",
+    "tracking_authorization_status": "AUTHORIZED"
+  },
+  "regs": {
+    "coppa": false,
+    "gdpr": false,
+    "iab": {}
+  },
+  "test": false,
+  "tmax": 500,
+  "ad_object": {
+    "auction_id": "6050",
+    "auction_pricefloor": 0.001,
+    "demands": {
+      "adikteev": {
+        "token": "token-is-needed"
+      }
+    },
+    "id": "f2d0dc19-b43f-43c1-8ca0-ae895ec76970",
+    "banner": {
+      "format": "BANNER"
+    },
+    "orientation": "PORTRAIT"
+  }
+}

--- a/internal/sdkapi/v2/apihandlers/testdata/auction/adikteev/android_adikteev_banner_mrec.json
+++ b/internal/sdkapi/v2/apihandlers/testdata/auction/adikteev/android_adikteev_banner_mrec.json
@@ -63,7 +63,7 @@
     "auction_pricefloor": 0.001,
     "demands": {
       "adikteev": {
-        "token": "token-is-needed"
+        "token": "sdk-instance-id"
       }
     },
     "id": "f2d0dc19-b43f-43c1-8ca0-ae895ec76970",

--- a/internal/sdkapi/v2/apihandlers/testdata/auction/adikteev/android_adikteev_banner_mrec.json
+++ b/internal/sdkapi/v2/apihandlers/testdata/auction/adikteev/android_adikteev_banner_mrec.json
@@ -1,0 +1,75 @@
+{
+  "adapters": {
+    "adikteev": {
+      "version": "1",
+      "sdk_version": "11.8.2"
+    }
+  },
+  "device": {
+    "connection_type": "WIFI",
+    "model": "Google Pixel 3",
+    "hwv": "blueline",
+    "h": 2028,
+    "js": 1,
+    "language": "en_US",
+    "make": "Google",
+    "os": "android",
+    "osv": "12",
+    "ppi": 440,
+    "pxratio": 3.0,
+    "type": "PHONE",
+    "ua": "Mozilla/5.0 (Linux; Android 12; Pixel 3 Build/SP1A.210812.016.C1; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/114.0.5735.131 Mobile Safari/537.36",
+    "w": 1080
+  },
+  "app": {
+    "bundle": "com.demo.tetris",
+    "key": "tetris_2005",
+    "framework": "native",
+    "version": "1.0"
+  },
+  "token": "{}",
+  "session": {
+    "battery": 100,
+    "cpu_usage": 0.7714286,
+    "id": "d0b9ec0e-60e9-4501-bcbc-67712562dab9",
+    "launch_monotonic_ts": 68406545,
+    "launch_ts": 1687863971253,
+    "memory_warnings_monotonic_ts": [],
+    "memory_warnings_ts": [],
+    "start_monotonic_ts": 68406545,
+    "monotonic_ts": 68471084,
+    "ram_size": 3753299968,
+    "ram_used": 413565952,
+    "start_ts": 1687863971253,
+    "storage_free": 30742986752,
+    "storage_used": 24636485632,
+    "ts": 1687864035792
+  },
+  "user": {
+    "idg": "8020a0a6-5e55-4b8f-af9a-7b01a9aad4fc",
+    "coppa": false,
+    "idfa": "013b8c47-8beb-41b4-aefe-60fe466f9fd8",
+    "tracking_authorization_status": "AUTHORIZED"
+  },
+  "regs": {
+    "coppa": false,
+    "gdpr": false,
+    "iab": {}
+  },
+  "test": false,
+  "tmax": 500,
+  "ad_object": {
+    "auction_id": "6050",
+    "auction_pricefloor": 0.001,
+    "demands": {
+      "adikteev": {
+        "token": "token-is-needed"
+      }
+    },
+    "id": "f2d0dc19-b43f-43c1-8ca0-ae895ec76970",
+    "banner": {
+      "format": "MREC"
+    },
+    "orientation": "PORTRAIT"
+  }
+}

--- a/internal/sdkapi/v2/apihandlers/testdata/auction/adikteev/android_adikteev_interstitial.json
+++ b/internal/sdkapi/v2/apihandlers/testdata/auction/adikteev/android_adikteev_interstitial.json
@@ -63,7 +63,7 @@
     "auction_pricefloor": 0.001,
     "demands": {
       "adikteev": {
-        "token": "token-is-needed"
+        "token": "sdk-instance-id"
       }
     },
     "id": "f2d0dc19-b43f-43c1-8ca0-ae895ec76970",

--- a/internal/sdkapi/v2/apihandlers/testdata/auction/adikteev/android_adikteev_interstitial.json
+++ b/internal/sdkapi/v2/apihandlers/testdata/auction/adikteev/android_adikteev_interstitial.json
@@ -1,0 +1,73 @@
+{
+  "adapters": {
+    "adikteev": {
+      "version": "1",
+      "sdk_version": "11.8.2"
+    }
+  },
+  "device": {
+    "connection_type": "WIFI",
+    "model": "Google Pixel 3",
+    "hwv": "blueline",
+    "h": 2028,
+    "js": 1,
+    "language": "en_US",
+    "make": "Google",
+    "os": "android",
+    "osv": "12",
+    "ppi": 440,
+    "pxratio": 3.0,
+    "type": "PHONE",
+    "ua": "Mozilla/5.0 (Linux; Android 12; Pixel 3 Build/SP1A.210812.016.C1; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/114.0.5735.131 Mobile Safari/537.36",
+    "w": 1080
+  },
+  "app": {
+    "bundle": "com.demo.tetris",
+    "key": "tetris_2005",
+    "framework": "native",
+    "version": "1.0"
+  },
+  "token": "{}",
+  "session": {
+    "battery": 100,
+    "cpu_usage": 0.7714286,
+    "id": "d0b9ec0e-60e9-4501-bcbc-67712562dab9",
+    "launch_monotonic_ts": 68406545,
+    "launch_ts": 1687863971253,
+    "memory_warnings_monotonic_ts": [],
+    "memory_warnings_ts": [],
+    "start_monotonic_ts": 68406545,
+    "monotonic_ts": 68471084,
+    "ram_size": 3753299968,
+    "ram_used": 413565952,
+    "start_ts": 1687863971253,
+    "storage_free": 30742986752,
+    "storage_used": 24636485632,
+    "ts": 1687864035792
+  },
+  "user": {
+    "idg": "8020a0a6-5e55-4b8f-af9a-7b01a9aad4fc",
+    "coppa": false,
+    "idfa": "013b8c47-8beb-41b4-aefe-60fe466f9fd8",
+    "tracking_authorization_status": "AUTHORIZED"
+  },
+  "regs": {
+    "coppa": false,
+    "gdpr": false,
+    "iab": {}
+  },
+  "test": false,
+  "tmax": 500,
+  "ad_object": {
+    "auction_id": "6050",
+    "auction_pricefloor": 0.001,
+    "demands": {
+      "adikteev": {
+        "token": "token-is-needed"
+      }
+    },
+    "id": "f2d0dc19-b43f-43c1-8ca0-ae895ec76970",
+    "interstitial": {},
+    "orientation": "PORTRAIT"
+  }
+}

--- a/internal/sdkapi/v2/apihandlers/testdata/auction/adikteev/android_adikteev_rewarded.json
+++ b/internal/sdkapi/v2/apihandlers/testdata/auction/adikteev/android_adikteev_rewarded.json
@@ -63,7 +63,7 @@
     "auction_pricefloor": 0.001,
     "demands": {
       "adikteev": {
-        "token": "token-is-needed"
+        "token": "sdk-instance-id"
       }
     },
     "id": "f2d0dc19-b43f-43c1-8ca0-ae895ec76970",

--- a/internal/sdkapi/v2/apihandlers/testdata/auction/adikteev/android_adikteev_rewarded.json
+++ b/internal/sdkapi/v2/apihandlers/testdata/auction/adikteev/android_adikteev_rewarded.json
@@ -1,0 +1,73 @@
+{
+  "adapters": {
+    "adikteev": {
+      "version": "1",
+      "sdk_version": "11.8.2"
+    }
+  },
+  "device": {
+    "connection_type": "WIFI",
+    "model": "Google Pixel 3",
+    "hwv": "blueline",
+    "h": 2028,
+    "js": 1,
+    "language": "en_US",
+    "make": "Google",
+    "os": "android",
+    "osv": "12",
+    "ppi": 440,
+    "pxratio": 3.0,
+    "type": "PHONE",
+    "ua": "Mozilla/5.0 (Linux; Android 12; Pixel 3 Build/SP1A.210812.016.C1; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/114.0.5735.131 Mobile Safari/537.36",
+    "w": 1080
+  },
+  "app": {
+    "bundle": "com.demo.tetris",
+    "key": "tetris_2005",
+    "framework": "native",
+    "version": "1.0"
+  },
+  "token": "{}",
+  "session": {
+    "battery": 100,
+    "cpu_usage": 0.7714286,
+    "id": "d0b9ec0e-60e9-4501-bcbc-67712562dab9",
+    "launch_monotonic_ts": 68406545,
+    "launch_ts": 1687863971253,
+    "memory_warnings_monotonic_ts": [],
+    "memory_warnings_ts": [],
+    "start_monotonic_ts": 68406545,
+    "monotonic_ts": 68471084,
+    "ram_size": 3753299968,
+    "ram_used": 413565952,
+    "start_ts": 1687863971253,
+    "storage_free": 30742986752,
+    "storage_used": 24636485632,
+    "ts": 1687864035792
+  },
+  "user": {
+    "idg": "8020a0a6-5e55-4b8f-af9a-7b01a9aad4fc",
+    "coppa": false,
+    "idfa": "013b8c47-8beb-41b4-aefe-60fe466f9fd8",
+    "tracking_authorization_status": "AUTHORIZED"
+  },
+  "regs": {
+    "coppa": false,
+    "gdpr": false,
+    "iab": {}
+  },
+  "test": false,
+  "tmax": 500,
+  "ad_object": {
+    "auction_id": "6050",
+    "auction_pricefloor": 0.001,
+    "demands": {
+      "adikteev": {
+        "token": "token-is-needed"
+      }
+    },
+    "id": "f2d0dc19-b43f-43c1-8ca0-ae895ec76970",
+    "rewarded": {},
+    "orientation": "PORTRAIT"
+  }
+}

--- a/internal/sdkapi/v2/apihandlers/testdata/auction/adikteev/ios_adikteev_banner.json
+++ b/internal/sdkapi/v2/apihandlers/testdata/auction/adikteev/ios_adikteev_banner.json
@@ -63,7 +63,7 @@
     "auction_pricefloor": 0.001,
     "demands": {
       "adikteev": {
-        "token": "token-is-needed"
+        "token": "sdk-instance-id"
       }
     },
     "id": "f2d0dc19-b43f-43c1-8ca0-ae895ec76970",

--- a/internal/sdkapi/v2/apihandlers/testdata/auction/adikteev/ios_adikteev_banner.json
+++ b/internal/sdkapi/v2/apihandlers/testdata/auction/adikteev/ios_adikteev_banner.json
@@ -1,0 +1,75 @@
+{
+  "adapters": {
+    "adikteev": {
+      "version": "1",
+      "sdk_version": "11.8.2"
+    }
+  },
+  "device": {
+    "connection_type": "WIFI",
+    "model": "iPhone14,2",
+    "hwv": "iPhone14,2",
+    "h": 2556,
+    "js": 1,
+    "language": "en_US",
+    "make": "Apple",
+    "os": "ios",
+    "osv": "16.0",
+    "ppi": 460,
+    "pxratio": 3.0,
+    "type": "PHONE",
+    "ua": "Mozilla/5.0 (iPhone; CPU iPhone OS 16_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/16.0 Mobile/15E148 Safari/604.1",
+    "w": 1179
+  },
+  "app": {
+    "bundle": "com.demo.tetris",
+    "key": "tetris_2005",
+    "framework": "native",
+    "version": "1.0"
+  },
+  "token": "{}",
+  "session": {
+    "battery": 100,
+    "cpu_usage": 0.7714286,
+    "id": "d0b9ec0e-60e9-4501-bcbc-67712562dab9",
+    "launch_monotonic_ts": 68406545,
+    "launch_ts": 1687863971253,
+    "memory_warnings_monotonic_ts": [],
+    "memory_warnings_ts": [],
+    "start_monotonic_ts": 68406545,
+    "monotonic_ts": 68471084,
+    "ram_size": 3753299968,
+    "ram_used": 413565952,
+    "start_ts": 1687863971253,
+    "storage_free": 30742986752,
+    "storage_used": 24636485632,
+    "ts": 1687864035792
+  },
+  "user": {
+    "idg": "8020a0a6-5e55-4b8f-af9a-7b01a9aad4fc",
+    "coppa": false,
+    "idfa": "F40EF78F-01DD-4053-A657-061EC2DB55CC",
+    "tracking_authorization_status": "AUTHORIZED"
+  },
+  "regs": {
+    "coppa": false,
+    "gdpr": false,
+    "iab": {}
+  },
+  "test": false,
+  "tmax": 500,
+  "ad_object": {
+    "auction_id": "6050",
+    "auction_pricefloor": 0.001,
+    "demands": {
+      "adikteev": {
+        "token": "token-is-needed"
+      }
+    },
+    "id": "f2d0dc19-b43f-43c1-8ca0-ae895ec76970",
+    "banner": {
+      "format": "BANNER"
+    },
+    "orientation": "PORTRAIT"
+  }
+}

--- a/internal/sdkapi/v2/apihandlers/testdata/auction/adikteev/ios_adikteev_banner_mrec.json
+++ b/internal/sdkapi/v2/apihandlers/testdata/auction/adikteev/ios_adikteev_banner_mrec.json
@@ -63,7 +63,7 @@
     "auction_pricefloor": 0.001,
     "demands": {
       "adikteev": {
-        "token": "token-is-needed"
+        "token": "sdk-instance-id"
       }
     },
     "id": "f2d0dc19-b43f-43c1-8ca0-ae895ec76970",

--- a/internal/sdkapi/v2/apihandlers/testdata/auction/adikteev/ios_adikteev_banner_mrec.json
+++ b/internal/sdkapi/v2/apihandlers/testdata/auction/adikteev/ios_adikteev_banner_mrec.json
@@ -1,0 +1,75 @@
+{
+  "adapters": {
+    "adikteev": {
+      "version": "1",
+      "sdk_version": "11.8.2"
+    }
+  },
+  "device": {
+    "connection_type": "WIFI",
+    "model": "iPhone14,2",
+    "hwv": "iPhone14,2",
+    "h": 2556,
+    "js": 1,
+    "language": "en_US",
+    "make": "Apple",
+    "os": "ios",
+    "osv": "16.0",
+    "ppi": 460,
+    "pxratio": 3.0,
+    "type": "PHONE",
+    "ua": "Mozilla/5.0 (iPhone; CPU iPhone OS 16_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/16.0 Mobile/15E148 Safari/604.1",
+    "w": 1179
+  },
+  "app": {
+    "bundle": "com.demo.tetris",
+    "key": "tetris_2005",
+    "framework": "native",
+    "version": "1.0"
+  },
+  "token": "{}",
+  "session": {
+    "battery": 100,
+    "cpu_usage": 0.7714286,
+    "id": "d0b9ec0e-60e9-4501-bcbc-67712562dab9",
+    "launch_monotonic_ts": 68406545,
+    "launch_ts": 1687863971253,
+    "memory_warnings_monotonic_ts": [],
+    "memory_warnings_ts": [],
+    "start_monotonic_ts": 68406545,
+    "monotonic_ts": 68471084,
+    "ram_size": 3753299968,
+    "ram_used": 413565952,
+    "start_ts": 1687863971253,
+    "storage_free": 30742986752,
+    "storage_used": 24636485632,
+    "ts": 1687864035792
+  },
+  "user": {
+    "idg": "8020a0a6-5e55-4b8f-af9a-7b01a9aad4fc",
+    "coppa": false,
+    "idfa": "F40EF78F-01DD-4053-A657-061EC2DB55CC",
+    "tracking_authorization_status": "AUTHORIZED"
+  },
+  "regs": {
+    "coppa": false,
+    "gdpr": false,
+    "iab": {}
+  },
+  "test": false,
+  "tmax": 500,
+  "ad_object": {
+    "auction_id": "6050",
+    "auction_pricefloor": 0.001,
+    "demands": {
+      "adikteev": {
+        "token": "token-is-needed"
+      }
+    },
+    "id": "f2d0dc19-b43f-43c1-8ca0-ae895ec76970",
+    "banner": {
+      "format": "MREC"
+    },
+    "orientation": "PORTRAIT"
+  }
+}

--- a/internal/sdkapi/v2/apihandlers/testdata/auction/adikteev/ios_adikteev_interstitial.json
+++ b/internal/sdkapi/v2/apihandlers/testdata/auction/adikteev/ios_adikteev_interstitial.json
@@ -63,7 +63,7 @@
     "auction_pricefloor": 0.001,
     "demands": {
       "adikteev": {
-        "token": "token-is-needed"
+        "token": "sdk-instance-id"
       }
     },
     "id": "f2d0dc19-b43f-43c1-8ca0-ae895ec76970",

--- a/internal/sdkapi/v2/apihandlers/testdata/auction/adikteev/ios_adikteev_interstitial.json
+++ b/internal/sdkapi/v2/apihandlers/testdata/auction/adikteev/ios_adikteev_interstitial.json
@@ -1,0 +1,73 @@
+{
+  "adapters": {
+    "adikteev": {
+      "version": "1",
+      "sdk_version": "11.8.2"
+    }
+  },
+  "device": {
+    "connection_type": "WIFI",
+    "model": "iPhone14,2",
+    "hwv": "iPhone14,2",
+    "h": 2556,
+    "js": 1,
+    "language": "en_US",
+    "make": "Apple",
+    "os": "ios",
+    "osv": "16.0",
+    "ppi": 460,
+    "pxratio": 3.0,
+    "type": "PHONE",
+    "ua": "Mozilla/5.0 (iPhone; CPU iPhone OS 16_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/16.0 Mobile/15E148 Safari/604.1",
+    "w": 1179
+  },
+  "app": {
+    "bundle": "com.demo.tetris",
+    "key": "tetris_2005",
+    "framework": "native",
+    "version": "1.0"
+  },
+  "token": "{}",
+  "session": {
+    "battery": 100,
+    "cpu_usage": 0.7714286,
+    "id": "d0b9ec0e-60e9-4501-bcbc-67712562dab9",
+    "launch_monotonic_ts": 68406545,
+    "launch_ts": 1687863971253,
+    "memory_warnings_monotonic_ts": [],
+    "memory_warnings_ts": [],
+    "start_monotonic_ts": 68406545,
+    "monotonic_ts": 68471084,
+    "ram_size": 3753299968,
+    "ram_used": 413565952,
+    "start_ts": 1687863971253,
+    "storage_free": 30742986752,
+    "storage_used": 24636485632,
+    "ts": 1687864035792
+  },
+  "user": {
+    "idg": "8020a0a6-5e55-4b8f-af9a-7b01a9aad4fc",
+    "coppa": false,
+    "idfa": "F40EF78F-01DD-4053-A657-061EC2DB55CC",
+    "tracking_authorization_status": "AUTHORIZED"
+  },
+  "regs": {
+    "coppa": false,
+    "gdpr": false,
+    "iab": {}
+  },
+  "test": false,
+  "tmax": 500,
+  "ad_object": {
+    "auction_id": "6050",
+    "auction_pricefloor": 0.001,
+    "demands": {
+      "adikteev": {
+        "token": "token-is-needed"
+      }
+    },
+    "id": "f2d0dc19-b43f-43c1-8ca0-ae895ec76970",
+    "interstitial": {},
+    "orientation": "PORTRAIT"
+  }
+}

--- a/internal/sdkapi/v2/apihandlers/testdata/auction/adikteev/ios_adikteev_rewarded.json
+++ b/internal/sdkapi/v2/apihandlers/testdata/auction/adikteev/ios_adikteev_rewarded.json
@@ -63,7 +63,7 @@
     "auction_pricefloor": 0.001,
     "demands": {
       "adikteev": {
-        "token": "token-is-needed"
+        "token": "sdk-instance-id"
       }
     },
     "id": "f2d0dc19-b43f-43c1-8ca0-ae895ec76970",

--- a/internal/sdkapi/v2/apihandlers/testdata/auction/adikteev/ios_adikteev_rewarded.json
+++ b/internal/sdkapi/v2/apihandlers/testdata/auction/adikteev/ios_adikteev_rewarded.json
@@ -1,0 +1,73 @@
+{
+  "adapters": {
+    "adikteev": {
+      "version": "1",
+      "sdk_version": "11.8.2"
+    }
+  },
+  "device": {
+    "connection_type": "WIFI",
+    "model": "iPhone14,2",
+    "hwv": "iPhone14,2",
+    "h": 2556,
+    "js": 1,
+    "language": "en_US",
+    "make": "Apple",
+    "os": "ios",
+    "osv": "16.0",
+    "ppi": 460,
+    "pxratio": 3.0,
+    "type": "PHONE",
+    "ua": "Mozilla/5.0 (iPhone; CPU iPhone OS 16_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/16.0 Mobile/15E148 Safari/604.1",
+    "w": 1179
+  },
+  "app": {
+    "bundle": "com.demo.tetris",
+    "key": "tetris_2005",
+    "framework": "native",
+    "version": "1.0"
+  },
+  "token": "{}",
+  "session": {
+    "battery": 100,
+    "cpu_usage": 0.7714286,
+    "id": "d0b9ec0e-60e9-4501-bcbc-67712562dab9",
+    "launch_monotonic_ts": 68406545,
+    "launch_ts": 1687863971253,
+    "memory_warnings_monotonic_ts": [],
+    "memory_warnings_ts": [],
+    "start_monotonic_ts": 68406545,
+    "monotonic_ts": 68471084,
+    "ram_size": 3753299968,
+    "ram_used": 413565952,
+    "start_ts": 1687863971253,
+    "storage_free": 30742986752,
+    "storage_used": 24636485632,
+    "ts": 1687864035792
+  },
+  "user": {
+    "idg": "8020a0a6-5e55-4b8f-af9a-7b01a9aad4fc",
+    "coppa": false,
+    "idfa": "F40EF78F-01DD-4053-A657-061EC2DB55CC",
+    "tracking_authorization_status": "AUTHORIZED"
+  },
+  "regs": {
+    "coppa": false,
+    "gdpr": false,
+    "iab": {}
+  },
+  "test": false,
+  "tmax": 500,
+  "ad_object": {
+    "auction_id": "6050",
+    "auction_pricefloor": 0.001,
+    "demands": {
+      "adikteev": {
+        "token": "token-is-needed"
+      }
+    },
+    "id": "f2d0dc19-b43f-43c1-8ca0-ae895ec76970",
+    "rewarded": {},
+    "orientation": "PORTRAIT"
+  }
+}

--- a/justfile
+++ b/justfile
@@ -13,7 +13,17 @@ seed:
 sdk-api:
     go run ./cmd/bidon-sdkapi
 
-[arg('env', pattern='local|staging|prod')]
+#
+
+test-db:
+    docker compose up migrate-test
+
+test:
+    go test ./...
+
+#
+
+[arg('env', pattern='local|test|staging|prod')]
 switch env:
     ln -sf .env.{{env}} .env
 

--- a/justfile
+++ b/justfile
@@ -1,4 +1,9 @@
 
+registry := "registry.digitalocean.com/bidon-io"
+tag := `git rev-parse HEAD`
+
+# --- Development ---
+
 dev:
     docker compose -f docker-compose.dev.yml up
 
@@ -8,8 +13,60 @@ seed:
 sdk-api:
     go run ./cmd/bidon-sdkapi
 
-#
-
 [arg('env', pattern='local|staging|prod')]
 switch env:
     ln -sf .env.{{env}} .env
+
+# --- Local image builds ---
+# Build images into the local Docker store (--load) for testing with docker run / compose.
+# No registry login or push. Images are tagged with the same name as the registry for parity.
+
+_build target:
+    docker buildx build --load --platform linux/amd64 --target {{target}} --tag {{registry}}/{{target}}:{{tag}} .
+
+build-admin:
+    just _build bidon-admin
+
+build-sdkapi:
+    just _build bidon-sdkapi
+
+build-migrate:
+    just _build bidon-migrate
+
+build-seed:
+    just _build bidon-seed
+
+build-all:
+    just build-admin
+    just build-sdkapi
+    just build-migrate
+    just build-seed
+
+# --- CI / registry image builds ---
+# Build and push images to the DigitalOcean Container Registry (--push).
+# Run `just docker-login` before individual ci-build-* recipes; ci-build-all logs in once.
+
+docker-login:
+    doctl registry login
+
+_ci-build target:
+    docker buildx build --platform linux/amd64 --target {{target}} --tag {{registry}}/{{target}}:{{tag}} --push .
+
+ci-build-admin:
+    just _ci-build bidon-admin
+
+ci-build-sdkapi:
+    just _ci-build bidon-sdkapi
+
+ci-build-migrate:
+    just _ci-build bidon-migrate
+
+ci-build-seed:
+    just _ci-build bidon-seed
+
+ci-build-all:
+    just docker-login
+    just ci-build-admin
+    just ci-build-sdkapi
+    just ci-build-migrate
+    just ci-build-seed

--- a/justfile
+++ b/justfile
@@ -24,6 +24,9 @@ test-db:
 test:
     go test ./...
 
+precommit:
+    pre-commit run --all-files
+
 #
 
 [arg('env', pattern='local|test|staging|prod')]

--- a/justfile
+++ b/justfile
@@ -7,8 +7,11 @@ tag := `git rev-parse HEAD`
 dev:
     docker compose -f docker-compose.dev.yml up
 
+dev-down:
+    docker compose -f docker-compose.dev.yml down --remove-orphans
+
 seed:
-    go run ./cmd/bidon-seed -reset
+    go run ./cmd/bidon-seed -reset -sample
 
 sdk-api:
     go run ./cmd/bidon-sdkapi

--- a/sdk.http
+++ b/sdk.http
@@ -4,8 +4,8 @@ POST {{sdkapiHost}}/v2/config
 Content-Type: application/json
 X-Bidon-Version: 0.6.0
 
-#< ./internal/sdkapi/v2/apihandlers/testdata/config/tiz_request.json
 < ./internal/sdkapi/v2/apihandlers/testdata/auction/adikteev/adikteev_config_request.json
+
 
 
 ### Auction banner Adikteev — iOS
@@ -60,6 +60,26 @@ X-Bidon-Version: 0.6.0
 X-Forwarded-For: 94.24.105.28
 
 < ./internal/sdkapi/v2/apihandlers/testdata/auction/adikteev/android_adikteev_interstitial.json
+
+### Auction rewarded Adikteev — iOS
+
+POST {{sdkapiHost}}/v2/auction/rewarded
+Content-Type: application/json
+X-Bidon-Version: 0.6.0
+X-Forwarded-For: 94.24.105.28
+
+< ./internal/sdkapi/v2/apihandlers/testdata/auction/adikteev/ios_adikteev_rewarded.json
+
+### Auction rewarded Adikteev — Android
+
+POST {{sdkapiHost}}/v2/auction/rewarded
+Content-Type: application/json
+X-Bidon-Version: 0.6.0
+X-Forwarded-For: 94.24.105.28
+
+< ./internal/sdkapi/v2/apihandlers/testdata/auction/adikteev/android_adikteev_rewarded.json
+
+
 
 ### Auction banner PubRevPlus
 

--- a/sdk.http
+++ b/sdk.http
@@ -1,0 +1,71 @@
+
+### Config
+POST {{sdkapiHost}}/v2/config
+Content-Type: application/json
+X-Bidon-Version: 0.6.0
+
+#< ./internal/sdkapi/v2/apihandlers/testdata/config/tiz_request.json
+< ./internal/sdkapi/v2/apihandlers/testdata/auction/adikteev/adikteev_config_request.json
+
+
+### Auction banner Adikteev — iOS
+POST {{sdkapiHost}}/v2/auction/banner
+Content-Type: application/json
+X-Bidon-Version: 0.6.0
+X-Forwarded-For: 94.24.105.28
+
+< ./internal/sdkapi/v2/apihandlers/testdata/auction/adikteev/ios_adikteev_banner.json
+
+### Auction banner Adikteev — Android
+
+POST {{sdkapiHost}}/v2/auction/banner
+Content-Type: application/json
+X-Bidon-Version: 0.6.0
+X-Forwarded-For: 94.24.105.28
+
+< ./internal/sdkapi/v2/apihandlers/testdata/auction/adikteev/android_adikteev_banner.json
+
+### Auction banner Adikteev — iOS MREC
+
+POST {{sdkapiHost}}/v2/auction/banner
+Content-Type: application/json
+X-Bidon-Version: 0.6.0
+X-Forwarded-For: 94.24.105.28
+
+< ./internal/sdkapi/v2/apihandlers/testdata/auction/adikteev/ios_adikteev_banner_mrec.json
+
+### Auction banner Adikteev — Android MREC
+
+POST {{sdkapiHost}}/v2/auction/banner
+Content-Type: application/json
+X-Bidon-Version: 0.6.0
+X-Forwarded-For: 94.24.105.28
+
+< ./internal/sdkapi/v2/apihandlers/testdata/auction/adikteev/android_adikteev_banner_mrec.json
+
+### Auction interstitial Adikteev — iOS
+
+POST {{sdkapiHost}}/v2/auction/interstitial
+Content-Type: application/json
+X-Bidon-Version: 0.6.0
+X-Forwarded-For: 94.24.105.28
+
+< ./internal/sdkapi/v2/apihandlers/testdata/auction/adikteev/ios_adikteev_interstitial.json
+
+### Auction interstitial Adikteev — Android
+
+POST {{sdkapiHost}}/v2/auction/interstitial
+Content-Type: application/json
+X-Bidon-Version: 0.6.0
+X-Forwarded-For: 94.24.105.28
+
+< ./internal/sdkapi/v2/apihandlers/testdata/auction/adikteev/android_adikteev_interstitial.json
+
+### Auction banner PubRevPlus
+
+POST {{sdkapiHost}}/v2/auction/banner
+Content-Type: application/json
+X-Bidon-Version: 0.6.0
+X-Forwarded-For: 94.24.105.28
+
+< ./internal/sdkapi/v2/apihandlers/testdata/auction/ios_pubrevplus.json

--- a/web/bidon_ui/constants/DemandSourceOptions.js
+++ b/web/bidon_ui/constants/DemandSourceOptions.js
@@ -1,4 +1,5 @@
 export const DEMAND_SOURCE_OPTIONS = [
+  { label: "Adikteev", value: "DemandSourceAccount::Adikteev" },
   { label: "Admob", value: "DemandSourceAccount::Admob" },
   { label: "Amazon", value: "DemandSourceAccount::Amazon" },
   { label: "Applovin", value: "DemandSourceAccount::Applovin" },

--- a/web/bidon_ui/constants/Networks.js
+++ b/web/bidon_ui/constants/Networks.js
@@ -3,6 +3,11 @@
  * accountType, and bidding/waterfall membership.
  */
 export const NETWORK_DEFS = [
+  {
+    key: "adikteev",
+    label: "Adikteev",
+    accountType: "DemandSourceAccount::Adikteev",
+  },
   { key: "admob", label: "AdMob", accountType: "DemandSourceAccount::Admob" },
   {
     key: "applovin",
@@ -117,6 +122,7 @@ export const WATERFALL_NETWORK_KEYS = [
 
 /** Keys that participate in bidding (RTB) auctions */
 export const BIDDING_NETWORK_KEYS = [
+  "adikteev",
   "amazon",
   "bidmachine",
   "bigoads",


### PR DESCRIPTION
- Add Adikteev DSP adapter and configuration.
- Make Adikteev adapter handle banners, interstitial and rewarded auctions.
- Add a test app with line items for all ad types that use Adikteev as bidder.
- Set `sdk_instance_id` on `app_demand_profile` and return it for Adikteev configuration and forwards it for bid req on `App.Ext`.