### PR TITLE
BAC-15: Make staging compose Coolify-preview-safe and expose Redpanda Console with basic auth

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -45,3 +45,5 @@ AWS_SECRET_ACCESS_KEY=xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
 # Copilot settings
 COPILOT_BASE_URL=127.0.0.1:8123
 
+# docker-compose.staging.yml / Coolify: Traefik basic auth for Redpanda Console (whole htpasswd line; set as secret).
+# REDPANDA_CONSOLE_BA_USERS=

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -97,6 +97,12 @@ services:
         condition: service_healthy
     environment:
       KAFKA_BROKERS: redpanda:9092
+    healthcheck:
+      test: ["CMD-SHELL", "wget -q --spider http://127.0.0.1:8080/admin/health || exit 1"]
+      interval: 15s
+      timeout: 5s
+      retries: 5
+      start_period: 15s
 
   migrate:
     image: golang:1.24-alpine

--- a/docker-compose.staging.yml
+++ b/docker-compose.staging.yml
@@ -94,6 +94,8 @@ services:
   # https://coolify.io/docs/knowledge-base/proxy/traefik/basic-auth#docker-compose-and-services
   redpanda-console:
     image: redpandadata/console:latest
+    expose:
+      - "8080"
     depends_on:
       redpanda:
         condition: service_healthy

--- a/docker-compose.staging.yml
+++ b/docker-compose.staging.yml
@@ -18,6 +18,12 @@ x-logging: &default-logging
 #   BIDON_SEED_TAG            — Docker image tag for bidon-seed
 #   MAXMIND_GEOIP_ACCOUNT_ID  — MaxMind account ID for GeoLite2-City updates
 #   MAXMIND_GEOIP_LICENSE_KEY — MaxMind license key for GeoLite2-City updates
+#   REDPANDA_CONSOLE_BA_USERS — Traefik basicAuth.users for redpanda-console only (never commit).
+#     Generate: htpasswd -nbBC 10 <user> '<password>'  →  one line: user:$2y$10$...
+#     Coolify: reference this var under redpanda-console.environment (below) so it is in the
+#     deployment .env and ${REDPANDA_CONSOLE_BA_USERS} in labels is interpolated — labels-only refs can stay literal.
+#     For bcrypt, mark the value “literal” in Coolify if $ characters get stripped.
+#     Gitignored .env beside compose: if Compose treats $ inside values as substitution, escape with $$ per $ in the hash segment.
 
 x-staging-db-env: &staging-db-env
   DATABASE_URL: ${DATABASE_URL}
@@ -72,9 +78,6 @@ services:
       - --node-id 0
       - --kafka-addr PLAINTEXT://0.0.0.0:29092,OUTSIDE://0.0.0.0:9092
       - --advertise-kafka-addr PLAINTEXT://redpanda:29092,OUTSIDE://localhost:9092
-    ports:
-      - "9092:9092"
-      - "29092:29092"
     volumes:
       - redpanda-data:/var/lib/redpanda/data
     healthcheck:
@@ -86,10 +89,26 @@ services:
     logging: *default-logging
     <<: *restart-policy
 
+  # Redpanda Console (UI): expose publicly via Coolify → Traefik; protect with Basic Auth middleware
+  # labels only on this service. Kafka brokers stay at redpanda:29092 without proxy auth — see Coolify docs:
+  # https://coolify.io/docs/knowledge-base/proxy/traefik/basic-auth#docker-compose-and-services
+  redpanda-console:
+    image: redpandadata/console:latest
+    depends_on:
+      redpanda:
+        condition: service_healthy
+    environment:
+      KAFKA_BROKERS: redpanda:29092
+      # Pass-through so Coolify/Compose picks up REDPANDA_CONSOLE_BA_USERS for label substitution (not used by the app).
+      REDPANDA_CONSOLE_BA_USERS: ${REDPANDA_CONSOLE_BA_USERS:?}
+    labels:
+      - "traefik.http.middlewares.redpanda-console-ba.basicauth.users=${REDPANDA_CONSOLE_BA_USERS}"
+      - "coolify.traefik.middlewares=redpanda-console-ba"
+    logging: *default-logging
+    <<: *restart-policy
+
   redis:
     image: redis:7-alpine
-    ports:
-      - "6379:6379"
     volumes:
       - redis-data:/data
     healthcheck:
@@ -108,9 +127,9 @@ services:
 
   bidon-admin:
     image: "registry.digitalocean.com/bidon-io/bidon-admin:${BIDON_ADMIN_TAG}"
-    ports:
-      - "1323:1323"
-      - "50051:50051"
+    expose:
+      - "1323"
+      - "50051"
     depends_on:
       migrate:
         condition: service_completed_successfully
@@ -130,8 +149,8 @@ services:
 
   bidon-sdkapi:
     image: "registry.digitalocean.com/bidon-io/bidon-sdkapi:${BIDON_SDKAPI_TAG}"
-    ports:
-      - "1324:1323"
+    expose:
+      - "1323"
     depends_on:
       geodb-maxmind:
         condition: service_healthy

--- a/docker-compose.staging.yml
+++ b/docker-compose.staging.yml
@@ -93,7 +93,7 @@ services:
   # labels only on this service. Kafka brokers stay at redpanda:29092 without proxy auth — see Coolify docs:
   # https://coolify.io/docs/knowledge-base/proxy/traefik/basic-auth#docker-compose-and-services
   redpanda-console:
-    image: redpandadata/console:latest
+    image: redpandadata/console:v2.8.15
     expose:
       - "8080"
     depends_on:
@@ -101,8 +101,12 @@ services:
         condition: service_healthy
     environment:
       KAFKA_BROKERS: redpanda:29092
-      # Pass-through so Coolify/Compose picks up REDPANDA_CONSOLE_BA_USERS for label substitution (not used by the app).
-      REDPANDA_CONSOLE_BA_USERS: ${REDPANDA_CONSOLE_BA_USERS:?}
+    healthcheck:
+      test: ["CMD-SHELL", "wget -q --spider http://127.0.0.1:8080/admin/health || exit 1"]
+      interval: 15s
+      timeout: 5s
+      retries: 5
+      start_period: 15s
     labels:
       - "traefik.http.middlewares.redpanda-console-ba.basicauth.users=${REDPANDA_CONSOLE_BA_USERS}"
       - "coolify.traefik.middlewares=redpanda-console-ba"


### PR DESCRIPTION
Remove host port conflicts that break concurrent Coolify preview deployments, and add a secured Redpanda Console for staging Kafka inspection.