### PR TITLE
BAC-16: Deploy admin UI as standalone Nuxt container with same-origin /api and /auth proxy

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,6 +10,27 @@ ARG APP_ENV=production
 COPY web/bidon_ui .
 RUN VITE_APP_ENV=${APP_ENV} yarn generate
 
+FROM node:22-alpine AS bidon-ui-builder
+
+WORKDIR /app
+
+COPY web/bidon_ui/package.json web/bidon_ui/yarn.lock ./
+RUN yarn install --frozen-lockfile
+
+ARG APP_ENV=production
+COPY web/bidon_ui .
+RUN VITE_APP_ENV=${APP_ENV} yarn build
+
+FROM node:22-alpine AS bidon-ui
+
+WORKDIR /app
+
+COPY --from=bidon-ui-builder /app/.output ./.output
+
+EXPOSE 3000
+
+CMD ["node", ".output/server/index.mjs"]
+
 FROM golang:1.24-alpine AS base
 
 WORKDIR /app

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -167,9 +167,7 @@ services:
   bidon-ui:
     image: node:22-alpine
     working_dir: /workspace/web/bidon_ui
-    # Clear Nuxt's generated cache (`.nuxt`) so it regenerates against the container's `node_modules`
-    # (important when `node_modules` is mounted via a Docker volume).
-    command: sh -c "rm -rf .nuxt node_modules/.cache && yarn install --frozen-lockfile && yarn dev --hostname 0.0.0.0 --port 3010"
+    command: yarn dev-container
     ports:
       - '3010:3010'
     depends_on:

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -173,6 +173,12 @@ services:
     depends_on:
       bidon-admin:
         condition: service_started
+    healthcheck:
+      test: ["CMD-SHELL", "wget -q --spider http://127.0.0.1:3010/ || exit 1"]
+      interval: 15s
+      timeout: 5s
+      retries: 5
+      start_period: 90s
     environment:
       NUXT_API_PROXY_TARGET: http://bidon-admin:1323
       # Force polling-based file watching so host file edits are reliably detected in Docker.

--- a/docker-compose.staging.yml
+++ b/docker-compose.staging.yml
@@ -16,6 +16,7 @@ x-logging: &default-logging
 #   BIDON_SDKAPI_TAG          — Docker image tag for bidon-sdkapi
 #   BIDON_MIGRATE_TAG         — Docker image tag for bidon-migrate
 #   BIDON_SEED_TAG            — Docker image tag for bidon-seed
+#   BIDON_UI_TAG              — Docker image tag for bidon-ui (e.g. git SHA from CI)
 #   MAXMIND_GEOIP_ACCOUNT_ID  — MaxMind account ID for GeoLite2-City updates
 #   MAXMIND_GEOIP_LICENSE_KEY — MaxMind license key for GeoLite2-City updates
 #   REDPANDA_CONSOLE_BA_USERS — Traefik basicAuth.users for redpanda-console only (never commit).
@@ -200,6 +201,17 @@ services:
     command: sh /scripts/init-admin.sh
     restart: "no"
     logging: *default-logging
+
+  bidon-ui:
+    image: "registry.digitalocean.com/bidon-io/bidon-ui:${BIDON_UI_TAG}"
+    expose:
+      - "3000"
+    depends_on:
+      - bidon-admin
+    environment:
+      NUXT_API_PROXY_TARGET: http://${SERVICE_NAME_BIDON_ADMIN:-bidon-admin}:1323
+    logging: *default-logging
+    <<: *restart-policy
 
 volumes:
   geodb:

--- a/docker-compose.staging.yml
+++ b/docker-compose.staging.yml
@@ -210,6 +210,12 @@ services:
       - bidon-admin
     environment:
       NUXT_API_PROXY_TARGET: http://${SERVICE_NAME_BIDON_ADMIN:-bidon-admin}:1323
+    healthcheck:
+      test: ["CMD-SHELL", "wget -q --spider http://127.0.0.1:3000/ || exit 1"]
+      interval: 15s
+      timeout: 5s
+      retries: 5
+      start_period: 15s
     logging: *default-logging
     <<: *restart-policy
 

--- a/docker/pre-commit/entrypoint.sh
+++ b/docker/pre-commit/entrypoint.sh
@@ -4,9 +4,10 @@ set -e
 TOOLS_DIR="${PRECOMMIT_TOOLS_DIR:-/go/precommit-tools}"
 export PATH="${TOOLS_DIR}/bin:${PATH}"
 
-if [ ! -f "${TOOLS_DIR}/.installed" ]; then
-	apk add --no-cache python3 git pre-commit curl
+# apk packages live in the container filesystem and are lost when the container exits.
+apk add --no-cache python3 git pre-commit curl
 
+if [ ! -f "${TOOLS_DIR}/.installed" ]; then
 	mkdir -p "${TOOLS_DIR}/bin"
 
 	BUF_VERSION=1.47.2

--- a/justfile
+++ b/justfile
@@ -52,11 +52,15 @@ build-migrate:
 build-seed:
     just _build bidon-seed
 
+build-ui:
+    just _build bidon-ui
+
 build-all:
     just build-admin
     just build-sdkapi
     just build-migrate
     just build-seed
+    just build-ui
 
 # --- CI / registry image builds ---
 # Build and push images to the DigitalOcean Container Registry (--push).
@@ -80,9 +84,13 @@ ci-build-migrate:
 ci-build-seed:
     just _ci-build bidon-seed
 
+ci-build-ui:
+    just _ci-build bidon-ui
+
 ci-build-all:
     just docker-login
     just ci-build-admin
     just ci-build-sdkapi
     just ci-build-migrate
     just ci-build-seed
+    just ci-bidon-ui

--- a/justfile
+++ b/justfile
@@ -93,4 +93,4 @@ ci-build-all:
     just ci-build-sdkapi
     just ci-build-migrate
     just ci-build-seed
-    just ci-bidon-ui
+    just ci-build-ui

--- a/web/bidon_ui/CLAUDE.md
+++ b/web/bidon_ui/CLAUDE.md
@@ -11,7 +11,7 @@ This file provides context and guidelines for working with the Bidon admin web U
 - Segments, Users, API Keys
 - AI Copilot (admin-only)
 
-The app is statically generated (`yarn generate`) and served by the Go backend (`cmd/bidon-admin`). There is no Node.js runtime in production.
+The app is built with `yarn build` and deployed as a standalone Nuxt/Node.js container (`bidon-ui`). A Nitro server-side middleware proxies `/api/**` and `/auth/**` to the Go `bidon-admin` backend — no reverse proxy (nginx/caddy) needed between the browser and the API.
 
 ## Tech Stack
 
@@ -31,7 +31,7 @@ The app is statically generated (`yarn generate`) and served by the Go backend (
 
 **Routing:** File-based (Nuxt pages directory)
 **Mode:** SPA (`ssr: false`)
-**Build output:** `.output/public/` → copied to `../cmd/bidon-admin/web/ui`
+**Build output:** `.output/` — Nitro server entry at `.output/server/index.mjs`, static assets at `.output/public/`
 
 ## Project Structure
 
@@ -245,20 +245,27 @@ yarn lint
 yarn lintfix
 ```
 
-**Backend proxy:** `nuxt.config.ts` proxies `/auth/**` and `/api/**` to `http://localhost:1323`.
+**Backend proxy:** `server/middleware/proxy.ts` forwards `/api/**` and `/auth/**` to `NUXT_API_PROXY_TARGET` (defaults to `http://localhost:1323` in dev).
 
 ## Build & Deployment
 
+The UI runs as a standalone Nuxt/Node.js container (`bidon-ui`). A Nitro server-side middleware (`server/middleware/proxy.ts`) forwards `/api/**` and `/auth/**` requests to the Go `bidon-admin` backend, providing same-origin API access without an external reverse proxy.
+
 ```bash
-# Generate static files
-yarn generate
-# → .output/public/
+# Build for production (outputs Nitro server + static assets to .output/)
+yarn build
 
-# Copy to Go binary
-cp -rf .output/public/ ../cmd/bidon-admin/web/ui
-
-# The Go server serves the static files — no Node.js in production
+# Run the production server
+node .output/server/index.mjs
+# → http://localhost:3000
 ```
+
+**Required environment variable:**
+- `NUXT_API_PROXY_TARGET` — URL of the Go `bidon-admin` backend (e.g. `http://bidon-admin:1323`). A warning is logged at startup if unset; falls back to `http://localhost:1323`.
+
+**Docker target:** `bidon-ui` in the root `Dockerfile` (uses `yarn build`, runs Node.js).
+
+**Note:** The root `Dockerfile` also contains a `bidon-admin-builder` stage that still embeds static files (via `yarn generate`) into the Go binary for deployments that do not use the separate `bidon-ui` container.
 
 ## Testing
 

--- a/web/bidon_ui/middleware/auth.global.js
+++ b/web/bidon_ui/middleware/auth.global.js
@@ -3,7 +3,7 @@ export default defineNuxtRouteMiddleware(async (to) => {
 
   if (authStore.isAuthorized && !authStore.currentUser) {
     try {
-      const currentUser = await $apiFetch("users/me");
+      const currentUser = await $apiFetch("/users/me");
       authStore.setCurrentUser(currentUser);
     } catch (e) {
       if (e.response.status === 401) {

--- a/web/bidon_ui/nuxt.config.ts
+++ b/web/bidon_ui/nuxt.config.ts
@@ -1,7 +1,4 @@
 // https://nuxt.com/docs/api/configuration/nuxt-config
-const apiProxyTarget =
-  process.env.NUXT_API_PROXY_TARGET || "http://localhost:1323";
-
 export default defineNuxtConfig({
   alias: {
     assets: "/<rootDir>/assets",
@@ -10,6 +7,7 @@ export default defineNuxtConfig({
   ssr: false,
 
   runtimeConfig: {
+    apiProxyTarget: "http://localhost:1323",
     public: {
       copilotBase: "/api/copilot",
     },
@@ -81,11 +79,6 @@ export default defineNuxtConfig({
 
   build: {
     transpile: ["primevue"],
-  },
-
-  routeRules: {
-    "/auth/**": { proxy: `${apiProxyTarget}/auth/**` },
-    "/api/**": { proxy: `${apiProxyTarget}/api/**` },
   },
 
   compatibilityDate: "2024-10-31",

--- a/web/bidon_ui/package.json
+++ b/web/bidon_ui/package.json
@@ -8,6 +8,7 @@
   "scripts": {
     "build": "nuxt build",
     "dev": "nuxt dev",
+    "dev-container": "rm -rf .nuxt node_modules/.cache && yarn install --frozen-lockfile && nuxt dev --hostname 0.0.0.0 --port 3010",
     "generate": "nuxt generate",
     "preview": "nuxt preview",
     "postinstall": "nuxt prepare",

--- a/web/bidon_ui/server/middleware/proxy.ts
+++ b/web/bidon_ui/server/middleware/proxy.ts
@@ -1,9 +1,17 @@
-import { proxyRequest } from "h3";
+import { proxyRequest, createError } from "h3";
 
 export default defineEventHandler(async (event) => {
   const path = event.path;
   if (!path.startsWith("/api/") && !path.startsWith("/auth/")) return;
 
   const { apiProxyTarget } = useRuntimeConfig();
-  return proxyRequest(event, `${apiProxyTarget}${path}`);
+  try {
+    return await proxyRequest(event, `${apiProxyTarget}${path}`);
+  } catch (err) {
+    throw createError({
+      statusCode: 502,
+      statusMessage: "Bad Gateway",
+      message: `API backend unreachable: ${(err as Error).message}`,
+    });
+  }
 });

--- a/web/bidon_ui/server/middleware/proxy.ts
+++ b/web/bidon_ui/server/middleware/proxy.ts
@@ -1,0 +1,9 @@
+import { proxyRequest } from "h3";
+
+export default defineEventHandler(async (event) => {
+  const path = event.path;
+  if (!path.startsWith("/api/") && !path.startsWith("/auth/")) return;
+
+  const { apiProxyTarget } = useRuntimeConfig();
+  return proxyRequest(event, `${apiProxyTarget}${path}`);
+});

--- a/web/bidon_ui/server/plugins/log-api-proxy-target.ts
+++ b/web/bidon_ui/server/plugins/log-api-proxy-target.ts
@@ -1,0 +1,8 @@
+export default defineNitroPlugin(() => {
+  if (process.env.NUXT_API_PROXY_TARGET) return;
+
+  const { apiProxyTarget } = useRuntimeConfig();
+  console.warn(
+    `[bidon-ui] NUXT_API_PROXY_TARGET is not set; defaulting API proxy to ${apiProxyTarget}`,
+  );
+});

--- a/web/bidon_ui/services/ApiService.js
+++ b/web/bidon_ui/services/ApiService.js
@@ -1,9 +1,8 @@
 import axios from "axios";
 import { camelizeKeys, decamelizeKeys } from "humps";
-import { API_URL } from "@/constants/index.js";
 
 const api = axios.create({
-  baseURL: `${API_URL}api`,
+  baseURL: "/api",
   data: {},
   headers: {
     "X-Bidon-App": "web",

--- a/web/bidon_ui/utils/$apiFetch.ts
+++ b/web/bidon_ui/utils/$apiFetch.ts
@@ -10,7 +10,7 @@ export const $apiFetch = $fetch.create({
       typeof context.request === "string" &&
       !context.request.startsWith("http")
     ) {
-      context.request = `/api${context.request.startsWith("/") ? "" : "/"}${context.request}`;
+      context.request = `/api${context.request}`;
     }
 
     if (

--- a/web/bidon_ui/utils/$apiFetch.ts
+++ b/web/bidon_ui/utils/$apiFetch.ts
@@ -1,23 +1,16 @@
-import { API_URL } from "~/constants";
 import { camelizeKeys, decamelizeKeys } from "humps";
 import { $fetch } from "ofetch";
 
-const baseURL = `${API_URL}api`;
-
 export const $apiFetch = $fetch.create({
-  baseURL: baseURL,
   headers: {
     "X-Bidon-App": "web",
   },
   onRequest(context) {
-    // baseURL does not prepend if request matches it
-    // https://github.com/unjs/ufo/blob/496140d0abcc3c3636409eb403c4916fade58203/src/utils.ts#L231
-
     if (
       typeof context.request === "string" &&
-      context.request.startsWith("/api_keys")
+      !context.request.startsWith("http")
     ) {
-      context.request = `${baseURL}${context.request}`;
+      context.request = `/api${context.request.startsWith("/") ? "" : "/"}${context.request}`;
     }
 
     if (

--- a/web/bidon_ui/utils/$apiFetch.ts
+++ b/web/bidon_ui/utils/$apiFetch.ts
@@ -10,7 +10,8 @@ export const $apiFetch = $fetch.create({
       typeof context.request === "string" &&
       !context.request.startsWith("http")
     ) {
-      context.request = `/api${context.request}`;
+      const path = context.request.startsWith("/") ? context.request : `/${context.request}`;
+      context.request = `/api${path}`;
     }
 
     if (


### PR DESCRIPTION
Serve the admin UI from a Nuxt container that proxies /api and /auth to bidon-admin, use relative API paths in the frontend, and add CORS/OPTIONS fixes for decoupled deployments.