### PR TITLE
BAC-17: Fix auction config and app overview losing permission controls after …

### DIFF
--- a/web/bidon_ui/components/apps/AppAuctionConfigurationsSection.vue
+++ b/web/bidon_ui/components/apps/AppAuctionConfigurationsSection.vue
@@ -374,6 +374,16 @@ const toast = useToast();
 const auctionConfigs = ref([...props.initialAuctionConfigs]);
 const allLineItems = ref([...props.initialLineItems]);
 
+/** PATCH/POST responses return bare records without `_permissions`; keep prior permissions so the delete footer stays visible. */
+function mergeAuctionConfigApiPayload(prev, data) {
+  if (!data) return data;
+  return {
+    ...data,
+    _permissions: data._permissions ??
+      prev?._permissions ?? { update: true, delete: true },
+  };
+}
+
 const configSearch = ref("");
 const configAdTypeFilter = ref(null);
 
@@ -466,7 +476,10 @@ function handleAuctionConfigCreated(newConfig) {
 function handleAuctionConfigUpdated(updatedConfig) {
   const idx = auctionConfigs.value.findIndex((c) => c.id === updatedConfig.id);
   if (idx !== -1) {
-    auctionConfigs.value[idx] = updatedConfig;
+    auctionConfigs.value[idx] = mergeAuctionConfigApiPayload(
+      auctionConfigs.value[idx],
+      updatedConfig,
+    );
   }
   editingConfigId.value = null;
 }
@@ -537,7 +550,10 @@ async function handleLineItemCreated(newItem, configId) {
       method: "PATCH",
       body: { adUnitIds: updatedAdUnitIds },
     });
-    auctionConfigs.value[configIdx] = data;
+    auctionConfigs.value[configIdx] = mergeAuctionConfigApiPayload(
+      auctionConfigs.value[configIdx],
+      data,
+    );
     toast.add({
       severity: "success",
       summary: "Success",
@@ -582,7 +598,10 @@ async function handleLineItemDeleted(itemId) {
         (c) => c.id === config.id,
       );
       if (configIdx !== -1) {
-        auctionConfigs.value[configIdx] = data;
+        auctionConfigs.value[configIdx] = mergeAuctionConfigApiPayload(
+          auctionConfigs.value[configIdx],
+          data,
+        );
       }
     } catch (err) {
       toast.add({

--- a/web/bidon_ui/components/apps/AppAuctionConfigurationsSection.vue
+++ b/web/bidon_ui/components/apps/AppAuctionConfigurationsSection.vue
@@ -362,6 +362,7 @@
 
 <script setup>
 import useDeleteResource from "@/composables/useDeleteResource";
+import { mergeResourcePermissions } from "@/utils/mergeResourcePermissions";
 import { useToast } from "primevue/usetoast";
 
 const props = defineProps({
@@ -373,16 +374,6 @@ const props = defineProps({
 const toast = useToast();
 const auctionConfigs = ref([...props.initialAuctionConfigs]);
 const allLineItems = ref([...props.initialLineItems]);
-
-/** PATCH/POST responses return bare records without `_permissions`; keep prior permissions so the delete footer stays visible. */
-function mergeAuctionConfigApiPayload(prev, data) {
-  if (!data) return data;
-  return {
-    ...data,
-    _permissions: data._permissions ??
-      prev?._permissions ?? { update: true, delete: true },
-  };
-}
 
 const configSearch = ref("");
 const configAdTypeFilter = ref(null);
@@ -468,7 +459,7 @@ function cloneAuctionConfig(config) {
 }
 
 function handleAuctionConfigCreated(newConfig) {
-  auctionConfigs.value.push(newConfig);
+  auctionConfigs.value.push(mergeResourcePermissions(undefined, newConfig));
   showInlineConfigForm.value = false;
   cloneSourceConfig.value = null;
 }
@@ -476,7 +467,7 @@ function handleAuctionConfigCreated(newConfig) {
 function handleAuctionConfigUpdated(updatedConfig) {
   const idx = auctionConfigs.value.findIndex((c) => c.id === updatedConfig.id);
   if (idx !== -1) {
-    auctionConfigs.value[idx] = mergeAuctionConfigApiPayload(
+    auctionConfigs.value[idx] = mergeResourcePermissions(
       auctionConfigs.value[idx],
       updatedConfig,
     );
@@ -550,7 +541,7 @@ async function handleLineItemCreated(newItem, configId) {
       method: "PATCH",
       body: { adUnitIds: updatedAdUnitIds },
     });
-    auctionConfigs.value[configIdx] = mergeAuctionConfigApiPayload(
+    auctionConfigs.value[configIdx] = mergeResourcePermissions(
       auctionConfigs.value[configIdx],
       data,
     );
@@ -598,7 +589,7 @@ async function handleLineItemDeleted(itemId) {
         (c) => c.id === config.id,
       );
       if (configIdx !== -1) {
-        auctionConfigs.value[configIdx] = mergeAuctionConfigApiPayload(
+        auctionConfigs.value[configIdx] = mergeResourcePermissions(
           auctionConfigs.value[configIdx],
           data,
         );

--- a/web/bidon_ui/components/apps/AppDemandProfilesSection.vue
+++ b/web/bidon_ui/components/apps/AppDemandProfilesSection.vue
@@ -267,7 +267,7 @@ function onProfileUpdated(updated) {
 }
 
 function onProfileCreated(created) {
-  profiles.value.push(created);
+  profiles.value.push(mergeResourcePermissions(undefined, created));
   showCreateForm.value = false;
 }
 

--- a/web/bidon_ui/components/apps/AppDemandProfilesSection.vue
+++ b/web/bidon_ui/components/apps/AppDemandProfilesSection.vue
@@ -210,6 +210,7 @@
 <script setup>
 import useDeleteResource from "@/composables/useDeleteResource";
 import { NETWORK_DEFS } from "@/constants/Networks.js";
+import { mergeResourcePermissions } from "@/utils/mergeResourcePermissions";
 
 const props = defineProps({
   demandProfiles: { type: Array, required: true },
@@ -256,7 +257,12 @@ function toggleEdit(profileId) {
 
 function onProfileUpdated(updated) {
   const idx = profiles.value.findIndex((p) => p.id === updated.id);
-  if (idx !== -1) profiles.value[idx] = updated;
+  if (idx !== -1) {
+    profiles.value[idx] = mergeResourcePermissions(
+      profiles.value[idx],
+      updated,
+    );
+  }
   editingId.value = null;
 }
 

--- a/web/bidon_ui/components/apps/AppOverviewCard.vue
+++ b/web/bidon_ui/components/apps/AppOverviewCard.vue
@@ -89,6 +89,7 @@
 
 <script setup>
 import useDeleteResource from "@/composables/useDeleteResource";
+import { mergeResourcePermissions } from "@/utils/mergeResourcePermissions";
 
 const props = defineProps({
   resource: { type: Object, required: true },
@@ -96,27 +97,17 @@ const props = defineProps({
   resourcesPath: { type: String, required: true },
 });
 
-/** PATCH responses often omit `_permissions`; keep prior permissions so edit/delete controls stay correct. */
-function mergeAppResource(prev, data) {
-  if (!data) return data;
-  return {
-    ...data,
-    _permissions: data._permissions ??
-      prev?._permissions ?? { update: true, delete: true },
-  };
-}
-
-const mergedResource = ref(mergeAppResource(undefined, props.resource));
+const mergedResource = ref(mergeResourcePermissions(undefined, props.resource));
 
 watch(
   () => [props.id, props.resource],
   ([id, next], prevTuple) => {
     const prevId = prevTuple?.[0];
     if (prevTuple !== undefined && id !== prevId) {
-      mergedResource.value = mergeAppResource(undefined, next);
+      mergedResource.value = mergeResourcePermissions(undefined, next);
       return;
     }
-    mergedResource.value = mergeAppResource(mergedResource.value, next);
+    mergedResource.value = mergeResourcePermissions(mergedResource.value, next);
   },
 );
 

--- a/web/bidon_ui/components/apps/AppOverviewCard.vue
+++ b/web/bidon_ui/components/apps/AppOverviewCard.vue
@@ -6,16 +6,18 @@
           class="font-semibold text-lg"
           style="color: var(--bidon-text-primary)"
         >
-          {{ resource.humanName }}
+          {{ mergedResource.humanName }}
         </span>
-        <span class="badge badge-platform">{{ resource.platformId }}</span>
+        <span class="badge badge-platform">{{
+          mergedResource.platformId
+        }}</span>
         <span class="text-sm" style="color: var(--bidon-muted)">{{
-          resource.packageName
+          mergedResource.packageName
         }}</span>
       </div>
       <div class="flex gap-2 shrink-0">
         <NuxtLink
-          v-if="resource._permissions?.update"
+          v-if="mergedResource._permissions?.update"
           :to="`/apps/${id}/edit`"
           class="btn-edit btn-sm"
         >
@@ -40,17 +42,25 @@
           class="text-sm font-mono break-all flex items-center gap-1.5 min-w-0"
           style="color: var(--bidon-text-primary)"
         >
-          {{ field.value ? field.value(resource) : resource[field.key] }}
+          {{
+            field.value
+              ? field.value(mergedResource)
+              : mergedResource[field.key]
+          }}
           <button
             v-if="
               field.copyable &&
-              (field.value ? field.value(resource) : resource[field.key])
+              (field.value
+                ? field.value(mergedResource)
+                : mergedResource[field.key])
             "
             :aria-label="`Copy ${field.label}`"
             class="table-action-btn shrink-0"
             @click="
               copyField(
-                field.value ? field.value(resource) : resource[field.key],
+                field.value
+                  ? field.value(mergedResource)
+                  : mergedResource[field.key],
               )
             "
           >
@@ -61,7 +71,7 @@
     </div>
 
     <div
-      v-if="resource._permissions?.delete"
+      v-if="mergedResource._permissions?.delete"
       class="card-footer flex items-center justify-end"
     >
       <button
@@ -85,6 +95,30 @@ const props = defineProps({
   id: { type: [Number, String], required: true },
   resourcesPath: { type: String, required: true },
 });
+
+/** PATCH responses often omit `_permissions`; keep prior permissions so edit/delete controls stay correct. */
+function mergeAppResource(prev, data) {
+  if (!data) return data;
+  return {
+    ...data,
+    _permissions: data._permissions ??
+      prev?._permissions ?? { update: true, delete: true },
+  };
+}
+
+const mergedResource = ref(mergeAppResource(undefined, props.resource));
+
+watch(
+  () => [props.id, props.resource],
+  ([id, next], prevTuple) => {
+    const prevId = prevTuple?.[0];
+    if (prevTuple !== undefined && id !== prevId) {
+      mergedResource.value = mergeAppResource(undefined, next);
+      return;
+    }
+    mergedResource.value = mergeAppResource(mergedResource.value, next);
+  },
+);
 
 const deleteHandle = useDeleteResource({
   path: props.resourcesPath,

--- a/web/bidon_ui/utils/mergeResourcePermissions.js
+++ b/web/bidon_ui/utils/mergeResourcePermissions.js
@@ -1,0 +1,9 @@
+/** PATCH/POST responses return bare records without `_permissions`; keep prior permissions for UI controls. */
+export function mergeResourcePermissions(prev, data) {
+  if (!data) return data;
+  return {
+    ...data,
+    _permissions: data._permissions ??
+      prev?._permissions ?? { update: true, delete: true },
+  };
+}

--- a/web/bidon_ui/utils/mergeResourcePermissions.js
+++ b/web/bidon_ui/utils/mergeResourcePermissions.js
@@ -1,4 +1,13 @@
-/** PATCH/POST responses return bare records without `_permissions`; keep prior permissions for UI controls. */
+/**
+ * Merge API payload into local state without dropping `_permissions`.
+ *
+ * PATCH/POST responses return bare records (no `_permissions`); list/GET responses include them.
+ *
+ * - **Update:** `prev` is the existing row — we keep `prev._permissions` when the response omits them.
+ * - **Create:** `prev` is undefined — there is nothing to preserve, so the default applies.
+ *   Default `{ update: true, delete: true }` is intentional: the user just created the resource and
+ *   is effectively its owner; the backend still enforces authorization on actual mutations.
+ */
 export function mergeResourcePermissions(prev, data) {
   if (!data) return data;
   return {


### PR DESCRIPTION
…PATCH

Preserve _permissions when merging PATCH/POST responses into local state, since bare records omit instance permissions.

- AppAuctionConfigurationsSection: merge helper for configs updated inline, including line-item link/unlink PATCH flows.
- AppOverviewCard: merged resource ref with id-aware resets when navigating.