### PR TITLE
BAC-26: Centralize OpenRTB bid-response parsing at the bidding builder

### DIFF
--- a/docs/backlog/BAC-26-openrtb-parse-bids-dto.md
+++ b/docs/backlog/BAC-26-openrtb-parse-bids-dto.md
@@ -30,7 +30,7 @@ This work moves the common OpenRTB parse to the **bidding builder call site**, s
 | Pattern | Adapters |
 |--------|----------|
 | Standard OpenRTB map only | adikteev, bidmachine, bigoads, meta, vkads, vungle, inmobi, mintegral, moloco, startio |
-| Extra: signaldata from bid ext | yandex, mobilefuse |
+| signaldata from bid ext | shared OpenRTB parser (was yandex, mobilefuse enrichers) |
 | Extra: payload from bid response ext (not adm) | taurusx |
 | Empty seatbid → no bid | inmobi, mintegral, yandex, taurusx |
 | Empty seatbid → error | moloco, startio |
@@ -62,7 +62,7 @@ Pipeline order:
 ### Optional capabilities (type-asserted at the call site)
 
 1. **Custom bid parser** — proprietary / non-OpenRTB networks (zmaticoo). Full ownership of parsing the raw response into `DemandResponse`.
-2. **OpenRTB bid enricher** — networks that need extra fields after the default OpenRTB map (yandex, mobilefuse, taurusx). Receives the demand response plus the parsed OpenRTB bid response / seat / bid and mutates the DTO.
+2. **OpenRTB bid enricher** — networks that need extra fields after the default OpenRTB map (taurusx). Receives the demand response plus the parsed OpenRTB bid response / seat / bid and mutates the DTO. `signaldata` is extracted by the shared parser.
 
 Most OpenRTB adapters implement **neither**.
 
@@ -71,7 +71,7 @@ Most OpenRTB adapters implement **neither**.
 - Standard HTTP status handling (align on the common 204 / auth-style failures / 200 set).
 - Unmarshal raw response to OpenRTB bid response.
 - Empty seat/bid policy — **default: treat as no-bid** (also fixes unchecked indexing). Decide whether moloco/startio keep an error policy via enricher/custom path or adopt no-bid.
-- Map standard fields into `NormalizedBid` (ids, price, adm payload, seat, notice URLs, raw bid ext for later enrichment).
+- Map standard fields into `NormalizedBid` (ids, price, adm payload, signaldata from bid.ext, seat, notice URLs, raw bid ext for later enrichment such as BAC-19 rendering).
 - Use `DemandResponse.DemandID` already set by execute; do not hardcode demand keys in the mapper.
 - Invoke optional OpenRTB enricher when present.
 
@@ -80,7 +80,7 @@ Most OpenRTB adapters implement **neither**.
 | Network | After change |
 |--------|----------------|
 | Most OpenRTB adapters | No parse-related methods |
-| yandex, mobilefuse | OpenRTB enricher for signaldata |
+| yandex, mobilefuse | No parse-related methods; signaldata via shared parser |
 | taurusx | OpenRTB enricher for payload-from-response-ext; stop parsing in `ExecuteRequest` |
 | zmaticoo | Custom bid parser; stop parsing in `ExecuteRequest` |
 | amazon | Unchanged (`FetchBids` bypass) |

--- a/docs/backlog/BAC-26-openrtb-parse-bids-dto.md
+++ b/docs/backlog/BAC-26-openrtb-parse-bids-dto.md
@@ -10,7 +10,7 @@
 
 ## Summary
 
-OpenRTB demand adapters each implement nearly identical `ParseBids` logic: HTTP status handling, unmarshalling the raw response, taking the first seat/bid, and mapping standard fields into `BidDemandResponse`. Only a few networks add custom extraction (e.g. signaldata, alternate payload source). Proprietary adapters (non-OpenRTB) need a full custom parse path.
+OpenRTB demand adapters each implement nearly identical `ParseBids` logic: HTTP status handling, unmarshalling the raw response, taking the first seat/bid, and mapping standard fields into `NormalizedBid`. Only a few networks add custom extraction (e.g. signaldata, alternate payload source). Proprietary adapters (non-OpenRTB) need a full custom parse path.
 
 This work moves the common OpenRTB parse to the **bidding builder call site**, so most networks no longer define `ParseBids` at all. Networks only opt in when they need enrichment or a fully custom parser.
 
@@ -71,7 +71,7 @@ Most OpenRTB adapters implement **neither**.
 - Standard HTTP status handling (align on the common 204 / auth-style failures / 200 set).
 - Unmarshal raw response to OpenRTB bid response.
 - Empty seat/bid policy — **default: treat as no-bid** (also fixes unchecked indexing). Decide whether moloco/startio keep an error policy via enricher/custom path or adopt no-bid.
-- Map standard fields into `BidDemandResponse` (ids, price, adm payload, seat, notice URLs, raw bid ext for later enrichment).
+- Map standard fields into `NormalizedBid` (ids, price, adm payload, seat, notice URLs, raw bid ext for later enrichment).
 - Use `DemandResponse.DemandID` already set by execute; do not hardcode demand keys in the mapper.
 - Invoke optional OpenRTB enricher when present.
 

--- a/docs/backlog/BAC-26-openrtb-parse-bids-dto.md
+++ b/docs/backlog/BAC-26-openrtb-parse-bids-dto.md
@@ -1,0 +1,128 @@
+# Backlog: Centralize OpenRTB bid response parsing
+
+**Status:** Backlog  
+**Linear:** [BAC-26](https://linear.app/bidon/issue/BAC-26/centralize-openrtb-parsebids-at-the-builder-with-optional-network)  
+**Branch:** `feature/BAC-26/openrtb-parse-bids-dto`  
+**Base:** `new-main`  
+**Blocks:** BAC-19 (uSDK rendering config) — rebase BAC-19 on top after this lands  
+
+---
+
+## Summary
+
+OpenRTB demand adapters each implement nearly identical `ParseBids` logic: HTTP status handling, unmarshalling the raw response, taking the first seat/bid, and mapping standard fields into `BidDemandResponse`. Only a few networks add custom extraction (e.g. signaldata, alternate payload source). Proprietary adapters (non-OpenRTB) need a full custom parse path.
+
+This work moves the common OpenRTB parse to the **bidding builder call site**, so most networks no longer define `ParseBids` at all. Networks only opt in when they need enrichment or a fully custom parser.
+
+---
+
+## Motivation
+
+- Remove duplicated parse/mapping across ~13 OpenRTB adapters.
+- Make the default path “request + execute only” for new OpenRTB networks.
+- Keep network-specific extraction as a small optional override.
+- Land on `new-main` before BAC-19 so rendering enrichment continues to run once after a single shared parse, and BAC-19 can rebase onto a thinner adapter surface.
+
+---
+
+## Current inventory (customization only)
+
+| Pattern | Adapters |
+|--------|----------|
+| Standard OpenRTB map only | adikteev, bidmachine, bigoads, meta, vkads, vungle, inmobi, mintegral, moloco, startio |
+| Extra: signaldata from bid ext | yandex, mobilefuse |
+| Extra: payload from bid response ext (not adm) | taurusx |
+| Empty seatbid → no bid | inmobi, mintegral, yandex, taurusx |
+| Empty seatbid → error | moloco, startio |
+| Empty seatbid unchecked (panic risk) | several “standard” adapters |
+| Non-OpenRTB custom parse | zmaticoo |
+| Separate fetch path (unchanged) | amazon (`FetchBids`) |
+
+Also: **taurusx** and **zmaticoo** currently parse inside `ExecuteRequest`. That must stop so the builder owns a single parse step.
+
+---
+
+## Design
+
+### Call site owns parsing
+
+In `bidding.Builder.processAdapter`, after `ExecuteRequest` succeeds, call a shared framework entrypoint (name TBD, e.g. `ParseDemandResponse`) instead of requiring `Adapter.ParseBids` on every network.
+
+Pipeline order:
+
+1. `ExecuteRequest` — status + raw body only  
+2. Shared parse / optional custom parse / optional enrich  
+3. Existing post-parse enrichment (BAC-19: `EnrichBid` / rendering) after rebase  
+
+### Required bidder interface shrinks
+
+`BidderInterface` keeps `CreateRequest` and `ExecuteRequest` only.  
+`ParseBids` is **removed** from the required interface.
+
+### Optional capabilities (type-asserted at the call site)
+
+1. **Custom bid parser** — proprietary / non-OpenRTB networks (zmaticoo). Full ownership of parsing the raw response into `DemandResponse`.
+2. **OpenRTB bid enricher** — networks that need extra fields after the default OpenRTB map (yandex, mobilefuse, taurusx). Receives the demand response plus the parsed OpenRTB bid response / seat / bid and mutates the DTO.
+
+Most OpenRTB adapters implement **neither**.
+
+### Shared OpenRTB path responsibilities
+
+- Standard HTTP status handling (align on the common 204 / auth-style failures / 200 set).
+- Unmarshal raw response to OpenRTB bid response.
+- Empty seat/bid policy — **default: treat as no-bid** (also fixes unchecked indexing). Decide whether moloco/startio keep an error policy via enricher/custom path or adopt no-bid.
+- Map standard fields into `BidDemandResponse` (ids, price, adm payload, seat, notice URLs, raw bid ext for later enrichment).
+- Use `DemandResponse.DemandID` already set by execute; do not hardcode demand keys in the mapper.
+- Invoke optional OpenRTB enricher when present.
+
+### Network outcomes
+
+| Network | After change |
+|--------|----------------|
+| Most OpenRTB adapters | No parse-related methods |
+| yandex, mobilefuse | OpenRTB enricher for signaldata |
+| taurusx | OpenRTB enricher for payload-from-response-ext; stop parsing in `ExecuteRequest` |
+| zmaticoo | Custom bid parser; stop parsing in `ExecuteRequest` |
+| amazon | Unchanged (`FetchBids` bypass) |
+
+---
+
+## Out of scope
+
+- Rendering / `EnrichBid` (BAC-19) — remains a separate post-parse step at the builder.
+- Auction-aware rendering defaults (e.g. container format from ad type).
+- Reworking amazon’s fetch path.
+- Changing CreateRequest / ExecuteRequest contracts beyond “execute must not parse”.
+
+---
+
+## Implementation steps
+
+1. Add shared parse entrypoint + optional enricher / custom-parser contracts; unit-test status, bad JSON, empty seatbid policy, default field map, enricher invocation.
+2. Switch `Builder.processAdapter` to the shared entrypoint.
+3. Remove `ParseBids` from the required bidder interface.
+4. Delete parse methods from standard OpenRTB adapters; add enrichers only where needed.
+5. Stop parse-inside-`ExecuteRequest` for taurusx and zmaticoo; keep zmaticoo on the custom parser path.
+6. Move per-adapter ParseBids tests to framework tests + enricher-specific tests.
+7. Merge to `new-main`, then rebase `feature/BAC-19/usdk-rendering-config`.
+
+---
+
+## Acceptance criteria
+
+- [x] Required bidder interface no longer includes `ParseBids`.
+- [x] Most OpenRTB networks define zero parse-related methods.
+- [x] Network-specific extraction exists only as optional OpenRTB enrichers (or custom parsers for non-OpenRTB).
+- [x] Single parse path in the builder; `ExecuteRequest` does not parse bids.
+- [x] Empty seatbid no longer panics on migrated OpenRTB adapters.
+- [x] Existing parse behavior covered by framework / enricher tests.
+- [x] Branch cut from `new-main`: `feature/BAC-26/openrtb-parse-bids-dto`.
+- [x] Linear issue created; BAC-19 marked blocked by this issue.
+
+---
+
+## Follow-ups after merge
+
+1. Rebase BAC-19; keep rendering enrichment immediately after the shared parse.
+2. Optionally unify empty-seatbid error vs no-bid policy for moloco/startio.
+3. Later: auction-context defaults on the same post-parse enrichment path.

--- a/internal/auction/builder_test.go
+++ b/internal/auction/builder_test.go
@@ -131,7 +131,7 @@ func TestBuilder_Build(t *testing.T) {
 					return bidding.AuctionResult{
 						RoundNumber: 0,
 						Bids: []adapters.DemandResponse{
-							{DemandID: "bidmachine", Bid: &adapters.BidDemandResponse{}},
+							{DemandID: "bidmachine", Bid: &adapters.NormalizedBid{}},
 						},
 					}, nil
 				},
@@ -178,7 +178,7 @@ func TestBuilder_Build(t *testing.T) {
 				},
 				BiddingAuctionResult: &bidding.AuctionResult{
 					Bids: []adapters.DemandResponse{
-						{DemandID: "bidmachine", Bid: &adapters.BidDemandResponse{}},
+						{DemandID: "bidmachine", Bid: &adapters.NormalizedBid{}},
 					},
 				},
 			},
@@ -206,7 +206,7 @@ func TestBuilder_Build(t *testing.T) {
 						HoldAuctionFunc: func(_ context.Context, _ *bidding.BuildParams) (bidding.AuctionResult, error) {
 							return bidding.AuctionResult{
 								Bids: []adapters.DemandResponse{
-									{DemandID: "meta", Bid: &adapters.BidDemandResponse{Price: 0.5}},
+									{DemandID: "meta", Bid: &adapters.NormalizedBid{Price: 0.5}},
 								},
 							}, nil
 						},
@@ -243,7 +243,7 @@ func TestBuilder_Build(t *testing.T) {
 				},
 				BiddingAuctionResult: &bidding.AuctionResult{
 					Bids: []adapters.DemandResponse{
-						{DemandID: "meta", Bid: &adapters.BidDemandResponse{Price: 0.5}},
+						{DemandID: "meta", Bid: &adapters.NormalizedBid{Price: 0.5}},
 					},
 				},
 			},
@@ -329,7 +329,7 @@ func TestBuilder_Build(t *testing.T) {
 						return bidding.AuctionResult{
 							RoundNumber: 0,
 							Bids: []adapters.DemandResponse{
-								{DemandID: "bidmachine", Bid: &adapters.BidDemandResponse{}},
+								{DemandID: "bidmachine", Bid: &adapters.NormalizedBid{}},
 							},
 						}, nil
 					},
@@ -358,7 +358,7 @@ func TestBuilder_Build(t *testing.T) {
 					return bidding.AuctionResult{
 						RoundNumber: 0,
 						Bids: []adapters.DemandResponse{
-							{DemandID: "bidmachine", Bid: &adapters.BidDemandResponse{}},
+							{DemandID: "bidmachine", Bid: &adapters.NormalizedBid{}},
 						},
 					}, nil
 				},
@@ -415,7 +415,7 @@ func TestBuilder_Build(t *testing.T) {
 				},
 				BiddingAuctionResult: &bidding.AuctionResult{
 					Bids: []adapters.DemandResponse{
-						{DemandID: "bidmachine", Bid: &adapters.BidDemandResponse{}},
+						{DemandID: "bidmachine", Bid: &adapters.NormalizedBid{}},
 					},
 				},
 			},
@@ -490,7 +490,7 @@ func TestAuctionResult_GetMaxBidPrice(t *testing.T) {
 			name: "single bid",
 			bids: []adapters.DemandResponse{
 				{
-					Bid: &adapters.BidDemandResponse{
+					Bid: &adapters.NormalizedBid{
 						Price: 1.5,
 					},
 				},
@@ -501,13 +501,13 @@ func TestAuctionResult_GetMaxBidPrice(t *testing.T) {
 			name: "multiple bids",
 			bids: []adapters.DemandResponse{
 				{
-					Bid: &adapters.BidDemandResponse{
+					Bid: &adapters.NormalizedBid{
 						Price: 1.5,
 					},
 				},
 				{},
 				{
-					Bid: &adapters.BidDemandResponse{
+					Bid: &adapters.NormalizedBid{
 						Price: 1,
 					},
 				},

--- a/internal/auction/service_test.go
+++ b/internal/auction/service_test.go
@@ -110,7 +110,7 @@ func TestService_Run(t *testing.T) {
 				},
 				BiddingAuctionResult: &bidding.AuctionResult{
 					Bids: []adapters.DemandResponse{
-						{DemandID: "bidmachine", Bid: &adapters.BidDemandResponse{}},
+						{DemandID: "bidmachine", Bid: &adapters.NormalizedBid{}},
 					},
 				},
 			}, nil
@@ -431,7 +431,7 @@ func TestService_Run(t *testing.T) {
 			},
 			BiddingAuctionResult: &bidding.AuctionResult{
 				Bids: []adapters.DemandResponse{
-					{DemandID: "bidmachine", Bid: &adapters.BidDemandResponse{}},
+					{DemandID: "bidmachine", Bid: &adapters.NormalizedBid{}},
 				},
 			},
 		}
@@ -678,7 +678,7 @@ func TestService_Run_BiddingWithDemandExt(t *testing.T) {
 					Bids: []adapters.DemandResponse{
 						{
 							DemandID: adapter.BidmachineKey,
-							Bid: &adapters.BidDemandResponse{
+							Bid: &adapters.NormalizedBid{
 								ID:      "bid123",
 								ImpID:   "imp123",
 								Price:   0.15,
@@ -794,7 +794,7 @@ func TestService_Run_BidmachineWithMediatorInBidding(t *testing.T) {
 					Bids: []adapters.DemandResponse{
 						{
 							DemandID: adapter.BidmachineKey,
-							Bid: &adapters.BidDemandResponse{
+							Bid: &adapters.NormalizedBid{
 								ID:      "bid123",
 								ImpID:   "imp123",
 								Price:   0.15,
@@ -968,7 +968,7 @@ func TestService_Run_BuildDemandExtVariousAdapters(t *testing.T) {
 						{
 							DemandID: adapter.AmazonKey,
 							SlotUUID: "amazon_slot",
-							Bid: &adapters.BidDemandResponse{
+							Bid: &adapters.NormalizedBid{
 								ID:      "amazon_bid",
 								ImpID:   "amazon_imp",
 								Price:   0.12,
@@ -977,7 +977,7 @@ func TestService_Run_BuildDemandExtVariousAdapters(t *testing.T) {
 						},
 						{
 							DemandID: adapter.MobileFuseKey,
-							Bid: &adapters.BidDemandResponse{
+							Bid: &adapters.NormalizedBid{
 								ID:         "mobilefuse_bid",
 								ImpID:      "mobilefuse_imp",
 								Price:      0.13,
@@ -987,7 +987,7 @@ func TestService_Run_BuildDemandExtVariousAdapters(t *testing.T) {
 						},
 						{
 							DemandID: adapter.YandexKey,
-							Bid: &adapters.BidDemandResponse{
+							Bid: &adapters.NormalizedBid{
 								ID:         "yandex_bid",
 								ImpID:      "yandex_imp",
 								Price:      0.15,
@@ -997,7 +997,7 @@ func TestService_Run_BuildDemandExtVariousAdapters(t *testing.T) {
 						},
 						{
 							DemandID: adapter.VKAdsKey,
-							Bid: &adapters.BidDemandResponse{
+							Bid: &adapters.NormalizedBid{
 								ID:      "vkads_bid_123",
 								ImpID:   "vkads_imp",
 								Price:   0.14,
@@ -1006,7 +1006,7 @@ func TestService_Run_BuildDemandExtVariousAdapters(t *testing.T) {
 						},
 						{
 							DemandID: "unknown_adapter",
-							Bid: &adapters.BidDemandResponse{
+							Bid: &adapters.NormalizedBid{
 								ID:      "unknown_bid",
 								ImpID:   "unknown_imp",
 								Price:   0.11,
@@ -1163,7 +1163,7 @@ func TestBidmachineWithPlacementID(t *testing.T) {
 					Bids: []adapters.DemandResponse{
 						{
 							DemandID: adapter.BidmachineKey,
-							Bid:      &adapters.BidDemandResponse{Payload: "test_payload", Price: 0.15}, // Higher than price floor
+							Bid:      &adapters.NormalizedBid{Payload: "test_payload", Price: 0.15}, // Higher than price floor
 						},
 					},
 				},

--- a/internal/bidding/adapters/adikteev/adikteev.go
+++ b/internal/bidding/adapters/adikteev/adikteev.go
@@ -5,10 +5,8 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
-	"fmt"
 	"io"
 	"net/http"
-	"strconv"
 
 	"github.com/bidon-io/bidon-backend/internal/ad"
 	"github.com/bidon-io/bidon-backend/internal/adapter"
@@ -162,41 +160,6 @@ func (a *AdikteevAdapter) ExecuteRequest(ctx context.Context, client *http.Clien
 	dr.Status = httpResp.StatusCode
 
 	return dr
-}
-
-func (a *AdikteevAdapter) ParseBids(dr *adapters.DemandResponse) (*adapters.DemandResponse, error) {
-	switch dr.Status {
-	case http.StatusNoContent:
-		return dr, nil
-	case http.StatusOK:
-		break
-	default:
-		return dr, fmt.Errorf("unexpected status code: %s", strconv.Itoa(dr.Status))
-	}
-
-	var bidResponse openrtb2.BidResponse
-	err := json.Unmarshal([]byte(dr.RawResponse), &bidResponse)
-	if err != nil {
-		return dr, err
-	}
-
-	seat := bidResponse.SeatBid[0]
-	bid := seat.Bid[0]
-
-	dr.Bid = &adapters.BidDemandResponse{
-		ID:       bid.ID,
-		ImpID:    bid.ImpID,
-		Price:    bid.Price,
-		Payload:  bid.AdM,
-		DemandID: adapter.AdikteevKey,
-		AdID:     bid.AdID,
-		SeatID:   seat.Seat,
-		LURL:     bid.LURL,
-		NURL:     bid.NURL,
-		BURL:     bid.BURL,
-	}
-
-	return dr, nil
 }
 
 // Builder builds a new instance of the Bidmachine adapter for the given bidder with the given config.

--- a/internal/bidding/adapters/adikteev/adikteev_test.go
+++ b/internal/bidding/adapters/adikteev/adikteev_test.go
@@ -354,12 +354,14 @@ func TestAdikteev_ParseBids(t *testing.T) {
 			name: "ParseBids Success",
 			params: ParseBidsTestParams{
 				DemandsResponse: adapters.DemandResponse{
+					DemandID:    "adikteev",
 					Status:      200,
 					RawResponse: rawResponse,
 				},
 			},
 			want: ParseBidsTestOutput{
 				DemandResponse: adapters.DemandResponse{
+					DemandID:    "adikteev",
 					Status:      200,
 					RawResponse: rawResponse,
 					Bid: &adapters.BidDemandResponse{
@@ -380,12 +382,14 @@ func TestAdikteev_ParseBids(t *testing.T) {
 			name: "ParseBids Bad Request",
 			params: ParseBidsTestParams{
 				DemandsResponse: adapters.DemandResponse{
+					DemandID:    "adikteev",
 					Status:      400,
 					RawResponse: rawResponse,
 				},
 			},
 			want: ParseBidsTestOutput{
 				DemandResponse: adapters.DemandResponse{
+					DemandID:    "adikteev",
 					Status:      400,
 					RawResponse: rawResponse,
 				},
@@ -396,12 +400,14 @@ func TestAdikteev_ParseBids(t *testing.T) {
 			name: "ParseBids No Content",
 			params: ParseBidsTestParams{
 				DemandsResponse: adapters.DemandResponse{
+					DemandID:    "adikteev",
 					Status:      204,
 					RawResponse: rawResponse,
 				},
 			},
 			want: ParseBidsTestOutput{
 				DemandResponse: adapters.DemandResponse{
+					DemandID:    "adikteev",
 					Status:      204,
 					RawResponse: rawResponse,
 				},
@@ -410,13 +416,13 @@ func TestAdikteev_ParseBids(t *testing.T) {
 		},
 	}
 	for _, tC := range testCases {
-		response, err := adapter.ParseBids(&tC.params.DemandsResponse)
+		response, err := adapters.ParseDemandResponse(&adapter, &tC.params.DemandsResponse)
 		got := ParseBidsTestOutput{
 			DemandResponse: *response,
 			Err:            err,
 		}
 		if diff := cmp.Diff(tC.want, got, cmp.Comparer(compareErrors)); diff != "" {
-			t.Errorf("%s: adapter.ParseBids(ctx, %v) mismatch (-want, +got):\n%s", tC.name, tC.params.DemandsResponse, diff)
+			t.Errorf("%s: adapters.ParseDemandResponse(&adapter, ctx, %v) mismatch (-want, +got):\n%s", tC.name, tC.params.DemandsResponse, diff)
 		}
 	}
 }

--- a/internal/bidding/adapters/adikteev/adikteev_test.go
+++ b/internal/bidding/adapters/adikteev/adikteev_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/prebid/openrtb/v19/adcom1"
 	"github.com/prebid/openrtb/v19/openrtb2"
 
@@ -266,7 +267,7 @@ func TestAdikteev_CreateRequest(t *testing.T) {
 			Request: request,
 			Err:     err,
 		}
-		if diff := cmp.Diff(tC.want, got, cmp.Comparer(compareErrors)); diff != "" {
+		if diff := cmp.Diff(tC.want, got, cmp.Comparer(compareErrors), cmpopts.IgnoreFields(adapters.NormalizedBid{}, "Ext")); diff != "" {
 			t.Errorf("%s: adapter.CreateRequest(ctx, %v, %v) mismatch (-want, +got):\n%s", tC.name, tC.params.BaseBidRequest, tC.params.AuctionRequest, diff)
 		}
 	}
@@ -364,7 +365,7 @@ func TestAdikteev_ParseBids(t *testing.T) {
 					DemandID:    "adikteev",
 					Status:      200,
 					RawResponse: rawResponse,
-					Bid: &adapters.BidDemandResponse{
+					Bid: &adapters.NormalizedBid{
 						ID:       "0",
 						ImpID:    "6579ca7b-7e2c-48b6-8915-46efa6530fb5",
 						Price:    1.5,
@@ -421,7 +422,7 @@ func TestAdikteev_ParseBids(t *testing.T) {
 			DemandResponse: *response,
 			Err:            err,
 		}
-		if diff := cmp.Diff(tC.want, got, cmp.Comparer(compareErrors)); diff != "" {
+		if diff := cmp.Diff(tC.want, got, cmp.Comparer(compareErrors), cmpopts.IgnoreFields(adapters.NormalizedBid{}, "Ext")); diff != "" {
 			t.Errorf("%s: adapters.ParseDemandResponse(&adapter, ctx, %v) mismatch (-want, +got):\n%s", tC.name, tC.params.DemandsResponse, diff)
 		}
 	}

--- a/internal/bidding/adapters/amazon/amazon.go
+++ b/internal/bidding/adapters/amazon/amazon.go
@@ -46,7 +46,7 @@ func (a *Adapter) FetchBids(auctionRequest *schema.AuctionRequest) ([]*adapters.
 			demandResponse := adapters.DemandResponse{
 				DemandID: adapter.AmazonKey,
 				SlotUUID: slot.SlotUUID,
-				Bid: &adapters.BidDemandResponse{
+				Bid: &adapters.NormalizedBid{
 					DemandID: adapter.AmazonKey,
 					ID:       ID.String(),
 					ImpID:    impID.String(),

--- a/internal/bidding/adapters/amazon/amazon_test.go
+++ b/internal/bidding/adapters/amazon/amazon_test.go
@@ -74,7 +74,7 @@ func TestAdapter_FetchBids(t *testing.T) {
 				{
 					DemandID: adapter.AmazonKey,
 					SlotUUID: "slot_uuid_1",
-					Bid: &adapters.BidDemandResponse{
+					Bid: &adapters.NormalizedBid{
 						DemandID: adapter.AmazonKey,
 						Price:    1.0,
 					},
@@ -82,7 +82,7 @@ func TestAdapter_FetchBids(t *testing.T) {
 				{
 					DemandID: adapter.AmazonKey,
 					SlotUUID: "slot_uuid_2",
-					Bid: &adapters.BidDemandResponse{
+					Bid: &adapters.NormalizedBid{
 						DemandID: adapter.AmazonKey,
 						Price:    2.0,
 					},

--- a/internal/bidding/adapters/bidder.go
+++ b/internal/bidding/adapters/bidder.go
@@ -2,6 +2,7 @@ package adapters
 
 import (
 	"context"
+	"encoding/json"
 	"net/http"
 
 	"github.com/bidon-io/bidon-backend/internal/adapter"
@@ -32,7 +33,7 @@ type DemandResponse struct {
 	RawRequest  string
 	RawResponse string
 	Status      int
-	Bid         *BidDemandResponse
+	Bid         *NormalizedBid
 	Error       error
 	ImpID       string
 	TagID       string
@@ -85,7 +86,9 @@ func (dr *DemandResponse) CanCache() bool {
 	return true
 }
 
-type BidDemandResponse struct {
+// NormalizedBid is the DSP-agnostic bid after network response parsing.
+// OpenRTB adapters fill Ext from seatbid.bid.ext; proprietary adapters leave it nil.
+type NormalizedBid struct {
 	Payload    string
 	Signaldata string
 	ID         string
@@ -97,6 +100,8 @@ type BidDemandResponse struct {
 	LURL       string
 	NURL       string
 	BURL       string
+	// Ext is the raw OpenRTB seatbid.bid.ext (nil for non-OpenRTB demands).
+	Ext json.RawMessage
 }
 
 type Token struct {

--- a/internal/bidding/adapters/bidder.go
+++ b/internal/bidding/adapters/bidder.go
@@ -14,10 +14,9 @@ type BidderInterface interface {
 	CreateRequest(openrtb.BidRequest, *schema.AuctionRequest) (openrtb.BidRequest, error)
 
 	// ExecuteRequest sends request to bidder endpoint.
+	// It must only populate Status / RawResponse (and transport errors);
+	// bid parsing is done by ParseDemandResponse at the builder call site.
 	ExecuteRequest(context.Context, *http.Client, openrtb.BidRequest) *DemandResponse
-
-	// ParseBids unpacks the server's response into Bids.
-	ParseBids(*DemandResponse) (*DemandResponse, error)
 }
 
 type Bidder struct {

--- a/internal/bidding/adapters/bidder.go
+++ b/internal/bidding/adapters/bidder.go
@@ -89,7 +89,8 @@ func (dr *DemandResponse) CanCache() bool {
 // NormalizedBid is the DSP-agnostic bid after network response parsing.
 // OpenRTB adapters fill Ext from seatbid.bid.ext; proprietary adapters leave it nil.
 type NormalizedBid struct {
-	Payload    string
+	Payload string
+	// Signaldata is extracted from seatbid.bid.ext.signaldata by the shared OpenRTB parser.
 	Signaldata string
 	ID         string
 	ImpID      string

--- a/internal/bidding/adapters/bidmachine/bidmachine.go
+++ b/internal/bidding/adapters/bidmachine/bidmachine.go
@@ -9,7 +9,6 @@ import (
 	"io"
 	"net/http"
 	"slices"
-	"strconv"
 
 	"github.com/gofrs/uuid/v5"
 	"github.com/prebid/openrtb/v19/adcom1"
@@ -189,49 +188,6 @@ func (a *BidmachineAdapter) ExecuteRequest(ctx context.Context, client *http.Cli
 	dr.Status = httpResp.StatusCode
 
 	return dr
-}
-
-func (a *BidmachineAdapter) ParseBids(dr *adapters.DemandResponse) (*adapters.DemandResponse, error) {
-	switch dr.Status {
-	case http.StatusNoContent:
-		return dr, nil
-	case http.StatusServiceUnavailable:
-		fallthrough
-	case http.StatusBadRequest:
-		fallthrough
-	case http.StatusUnauthorized:
-		fallthrough
-	case http.StatusForbidden:
-		return dr, fmt.Errorf("unauthorized request: %s", strconv.Itoa(dr.Status))
-	case http.StatusOK:
-		break
-	default:
-		return dr, fmt.Errorf("unexpected status code: %s", strconv.Itoa(dr.Status))
-	}
-
-	var bidResponse openrtb2.BidResponse
-	err := json.Unmarshal([]byte(dr.RawResponse), &bidResponse)
-	if err != nil {
-		return dr, err
-	}
-
-	seat := bidResponse.SeatBid[0]
-	bid := seat.Bid[0]
-
-	dr.Bid = &adapters.BidDemandResponse{
-		ID:       bid.ID,
-		ImpID:    bid.ImpID,
-		Price:    bid.Price,
-		Payload:  bid.AdM,
-		DemandID: adapter.BidmachineKey,
-		AdID:     bid.AdID,
-		SeatID:   seat.Seat,
-		LURL:     bid.LURL,
-		NURL:     bid.NURL,
-		BURL:     bid.BURL,
-	}
-
-	return dr, nil
 }
 
 // Builder builds a new instance of the Bidmachine adapter for the given bidder with the given config.

--- a/internal/bidding/adapters/bidmachine/bidmachine_test.go
+++ b/internal/bidding/adapters/bidmachine/bidmachine_test.go
@@ -425,12 +425,14 @@ func TestBidmachine_ParseBids(t *testing.T) {
 			name: "ParseBids Success",
 			params: ParseBidsTestParams{
 				DemandsResponse: adapters.DemandResponse{
+					DemandID:    "bidmachine",
 					Status:      200,
 					RawResponse: rawResponse,
 				},
 			},
 			want: ParseBidsTestOutput{
 				DemandResponse: adapters.DemandResponse{
+					DemandID:    "bidmachine",
 					Status:      200,
 					RawResponse: rawResponse,
 					Bid: &adapters.BidDemandResponse{
@@ -451,12 +453,14 @@ func TestBidmachine_ParseBids(t *testing.T) {
 			name: "ParseBids Bad Request",
 			params: ParseBidsTestParams{
 				DemandsResponse: adapters.DemandResponse{
+					DemandID:    "bidmachine",
 					Status:      400,
 					RawResponse: rawResponse,
 				},
 			},
 			want: ParseBidsTestOutput{
 				DemandResponse: adapters.DemandResponse{
+					DemandID:    "bidmachine",
 					Status:      400,
 					RawResponse: rawResponse,
 				},
@@ -467,12 +471,14 @@ func TestBidmachine_ParseBids(t *testing.T) {
 			name: "ParseBids No Conten",
 			params: ParseBidsTestParams{
 				DemandsResponse: adapters.DemandResponse{
+					DemandID:    "bidmachine",
 					Status:      204,
 					RawResponse: rawResponse,
 				},
 			},
 			want: ParseBidsTestOutput{
 				DemandResponse: adapters.DemandResponse{
+					DemandID:    "bidmachine",
 					Status:      204,
 					RawResponse: rawResponse,
 				},
@@ -481,13 +487,13 @@ func TestBidmachine_ParseBids(t *testing.T) {
 		},
 	}
 	for _, tC := range testCases {
-		response, err := adapter.ParseBids(&tC.params.DemandsResponse)
+		response, err := adapters.ParseDemandResponse(&adapter, &tC.params.DemandsResponse)
 		got := ParseBidsTestOutput{
 			DemandResponse: *response,
 			Err:            err,
 		}
 		if diff := cmp.Diff(tC.want, got, cmp.Comparer(compareErrors)); diff != "" {
-			t.Errorf("%s: adapter.ParseBids(ctx, %v) mismatch (-want, +got):\n%s", tC.name, tC.params.DemandsResponse, diff)
+			t.Errorf("%s: adapters.ParseDemandResponse(&adapter, ctx, %v) mismatch (-want, +got):\n%s", tC.name, tC.params.DemandsResponse, diff)
 		}
 	}
 }

--- a/internal/bidding/adapters/bidmachine/bidmachine_test.go
+++ b/internal/bidding/adapters/bidmachine/bidmachine_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/prebid/openrtb/v19/adcom1"
 	"github.com/prebid/openrtb/v19/openrtb2"
 
@@ -337,7 +338,7 @@ func TestBidmachine_CreateRequest(t *testing.T) {
 			Request: request,
 			Err:     err,
 		}
-		if diff := cmp.Diff(tC.want, got, cmp.Comparer(compareErrors)); diff != "" {
+		if diff := cmp.Diff(tC.want, got, cmp.Comparer(compareErrors), cmpopts.IgnoreFields(adapters.NormalizedBid{}, "Ext")); diff != "" {
 			t.Errorf("%s: adapter.CreateRequest(ctx, %v, %v) mismatch (-want, +got):\n%s", tC.name, tC.params.BaseBidRequest, tC.params.AuctionRequest, diff)
 		}
 	}
@@ -435,7 +436,7 @@ func TestBidmachine_ParseBids(t *testing.T) {
 					DemandID:    "bidmachine",
 					Status:      200,
 					RawResponse: rawResponse,
-					Bid: &adapters.BidDemandResponse{
+					Bid: &adapters.NormalizedBid{
 						ID:       "0",
 						ImpID:    "6579ca7b-7e2c-48b6-8915-46efa6530fb5",
 						Price:    1.5,
@@ -492,7 +493,7 @@ func TestBidmachine_ParseBids(t *testing.T) {
 			DemandResponse: *response,
 			Err:            err,
 		}
-		if diff := cmp.Diff(tC.want, got, cmp.Comparer(compareErrors)); diff != "" {
+		if diff := cmp.Diff(tC.want, got, cmp.Comparer(compareErrors), cmpopts.IgnoreFields(adapters.NormalizedBid{}, "Ext")); diff != "" {
 			t.Errorf("%s: adapters.ParseDemandResponse(&adapter, ctx, %v) mismatch (-want, +got):\n%s", tC.name, tC.params.DemandsResponse, diff)
 		}
 	}

--- a/internal/bidding/adapters/bigoads/bigoads.go
+++ b/internal/bidding/adapters/bigoads/bigoads.go
@@ -8,7 +8,6 @@ import (
 	"fmt"
 	"io"
 	"net/http"
-	"strconv"
 
 	"github.com/gofrs/uuid/v5"
 	"github.com/prebid/openrtb/v19/adcom1"
@@ -169,49 +168,6 @@ func (a *BigoAdsAdapter) ExecuteRequest(ctx context.Context, client *http.Client
 	dr.Status = httpResp.StatusCode
 
 	return dr
-}
-
-func (a *BigoAdsAdapter) ParseBids(dr *adapters.DemandResponse) (*adapters.DemandResponse, error) {
-	switch dr.Status {
-	case http.StatusNoContent:
-		return dr, nil
-	case http.StatusServiceUnavailable:
-		fallthrough
-	case http.StatusBadRequest:
-		fallthrough
-	case http.StatusUnauthorized:
-		fallthrough
-	case http.StatusForbidden:
-		return dr, fmt.Errorf("unauthorized request: %s", strconv.Itoa(dr.Status))
-	case http.StatusOK:
-		break
-	default:
-		return dr, fmt.Errorf("unexpected status code: %s", strconv.Itoa(dr.Status))
-	}
-
-	var bidResponse openrtb2.BidResponse
-	err := json.Unmarshal([]byte(dr.RawResponse), &bidResponse)
-	if err != nil {
-		return dr, err
-	}
-
-	seat := bidResponse.SeatBid[0]
-	bid := seat.Bid[0]
-
-	dr.Bid = &adapters.BidDemandResponse{
-		ID:       bid.ID,
-		ImpID:    bid.ImpID,
-		Price:    bid.Price,
-		Payload:  bid.AdM,
-		DemandID: adapter.BigoAdsKey,
-		AdID:     bid.AdID,
-		SeatID:   seat.Seat,
-		LURL:     bid.LURL,
-		NURL:     bid.NURL,
-		BURL:     bid.BURL,
-	}
-
-	return dr, nil
 }
 
 // Builder builds a new instance of the BigoAds adapter for the given bidder with the given config.

--- a/internal/bidding/adapters/bigoads/bigoads_test.go
+++ b/internal/bidding/adapters/bigoads/bigoads_test.go
@@ -345,12 +345,14 @@ func TestBigoAds_ParseBids(t *testing.T) {
 			name: "ParseBids Success",
 			params: ParseBidsTestParams{
 				DemandsResponse: adapters.DemandResponse{
+					DemandID:    "bigoads",
 					Status:      200,
 					RawResponse: rawResponse,
 				},
 			},
 			want: ParseBidsTestOutput{
 				DemandResponse: adapters.DemandResponse{
+					DemandID:    "bigoads",
 					Status:      200,
 					RawResponse: rawResponse,
 					Bid: &adapters.BidDemandResponse{
@@ -371,12 +373,14 @@ func TestBigoAds_ParseBids(t *testing.T) {
 			name: "ParseBids Bad Request",
 			params: ParseBidsTestParams{
 				DemandsResponse: adapters.DemandResponse{
+					DemandID:    "bigoads",
 					Status:      400,
 					RawResponse: rawResponse,
 				},
 			},
 			want: ParseBidsTestOutput{
 				DemandResponse: adapters.DemandResponse{
+					DemandID:    "bigoads",
 					Status:      400,
 					RawResponse: rawResponse,
 				},
@@ -387,12 +391,14 @@ func TestBigoAds_ParseBids(t *testing.T) {
 			name: "ParseBids No Content",
 			params: ParseBidsTestParams{
 				DemandsResponse: adapters.DemandResponse{
+					DemandID:    "bigoads",
 					Status:      204,
 					RawResponse: rawResponse,
 				},
 			},
 			want: ParseBidsTestOutput{
 				DemandResponse: adapters.DemandResponse{
+					DemandID:    "bigoads",
 					Status:      204,
 					RawResponse: rawResponse,
 				},
@@ -401,13 +407,13 @@ func TestBigoAds_ParseBids(t *testing.T) {
 		},
 	}
 	for _, tC := range testCases {
-		response, err := adapter.ParseBids(&tC.params.DemandsResponse)
+		response, err := adapters.ParseDemandResponse(&adapter, &tC.params.DemandsResponse)
 		got := ParseBidsTestOutput{
 			DemandResponse: *response,
 			Err:            err,
 		}
 		if diff := cmp.Diff(tC.want, got, cmp.Comparer(compareErrors)); diff != "" {
-			t.Errorf("%s: adapter.ParseBids(ctx, %v) mismatch (-want, +got):\n%s", tC.name, tC.params.DemandsResponse, diff)
+			t.Errorf("%s: adapters.ParseDemandResponse(&adapter, ctx, %v) mismatch (-want, +got):\n%s", tC.name, tC.params.DemandsResponse, diff)
 		}
 	}
 }

--- a/internal/bidding/adapters/bigoads/bigoads_test.go
+++ b/internal/bidding/adapters/bigoads/bigoads_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/prebid/openrtb/v19/adcom1"
 	"github.com/prebid/openrtb/v19/openrtb2"
 
@@ -257,7 +258,7 @@ func TestBigoAds_CreateRequest(t *testing.T) {
 			Request: request,
 			Err:     err,
 		}
-		if diff := cmp.Diff(tC.want, got, cmp.Comparer(compareErrors)); diff != "" {
+		if diff := cmp.Diff(tC.want, got, cmp.Comparer(compareErrors), cmpopts.IgnoreFields(adapters.NormalizedBid{}, "Ext")); diff != "" {
 			t.Errorf("%s: adapter.CreateRequest(ctx, %v, %v) mismatch (-want, +got):\n%s", tC.name, tC.params.BaseBidRequest, tC.params.AuctionRequest, diff)
 		}
 	}
@@ -355,7 +356,7 @@ func TestBigoAds_ParseBids(t *testing.T) {
 					DemandID:    "bigoads",
 					Status:      200,
 					RawResponse: rawResponse,
-					Bid: &adapters.BidDemandResponse{
+					Bid: &adapters.NormalizedBid{
 						ID:       "0",
 						ImpID:    "6579ca7b-7e2c-48b6-8915-46efa6530fb5",
 						Price:    1.5,
@@ -412,7 +413,7 @@ func TestBigoAds_ParseBids(t *testing.T) {
 			DemandResponse: *response,
 			Err:            err,
 		}
-		if diff := cmp.Diff(tC.want, got, cmp.Comparer(compareErrors)); diff != "" {
+		if diff := cmp.Diff(tC.want, got, cmp.Comparer(compareErrors), cmpopts.IgnoreFields(adapters.NormalizedBid{}, "Ext")); diff != "" {
 			t.Errorf("%s: adapters.ParseDemandResponse(&adapter, ctx, %v) mismatch (-want, +got):\n%s", tC.name, tC.params.DemandsResponse, diff)
 		}
 	}

--- a/internal/bidding/adapters/inmobi/inmobi.go
+++ b/internal/bidding/adapters/inmobi/inmobi.go
@@ -8,7 +8,6 @@ import (
 	"fmt"
 	"io"
 	"net/http"
-	"strconv"
 
 	"github.com/gofrs/uuid/v5"
 	"github.com/prebid/openrtb/v19/adcom1"
@@ -178,57 +177,6 @@ func (a *InMobiAdapter) ExecuteRequest(ctx context.Context, client *http.Client,
 	dr.RawResponse = string(responseBody)
 
 	return dr
-}
-
-func (a *InMobiAdapter) ParseBids(dr *adapters.DemandResponse) (*adapters.DemandResponse, error) {
-	switch dr.Status {
-	case http.StatusNoContent:
-		return dr, nil
-	case http.StatusServiceUnavailable:
-		fallthrough
-	case http.StatusBadRequest:
-		fallthrough
-	case http.StatusUnauthorized:
-		fallthrough
-	case http.StatusForbidden:
-		return dr, fmt.Errorf("unauthorized request: %s", strconv.Itoa(dr.Status))
-	case http.StatusOK:
-		break
-	default:
-		return dr, fmt.Errorf("unexpected status code: %s", strconv.Itoa(dr.Status))
-	}
-
-	var bidResponse openrtb2.BidResponse
-	err := json.Unmarshal([]byte(dr.RawResponse), &bidResponse)
-	if err != nil {
-		return dr, err
-	}
-
-	if len(bidResponse.SeatBid) == 0 {
-		return dr, nil
-	}
-
-	seat := bidResponse.SeatBid[0]
-	if len(seat.Bid) == 0 {
-		return dr, nil
-	}
-
-	bid := seat.Bid[0]
-
-	dr.Bid = &adapters.BidDemandResponse{
-		ID:       bid.ID,
-		ImpID:    bid.ImpID,
-		Price:    bid.Price,
-		Payload:  bid.AdM,
-		DemandID: adapter.InmobiKey,
-		AdID:     bid.AdID,
-		SeatID:   seat.Seat,
-		LURL:     bid.LURL,
-		NURL:     bid.NURL,
-		BURL:     bid.BURL,
-	}
-
-	return dr, nil
 }
 
 // Builder builds a new instance of the InMobi adapter for the given bidder with the given config.

--- a/internal/bidding/adapters/meta/meta.go
+++ b/internal/bidding/adapters/meta/meta.go
@@ -11,7 +11,6 @@ import (
 	"fmt"
 	"io"
 	"net/http"
-	"strconv"
 
 	"github.com/gofrs/uuid/v5"
 	"github.com/prebid/openrtb/v19/adcom1"
@@ -185,49 +184,6 @@ func (a *MetaAdapter) ExecuteRequest(ctx context.Context, client *http.Client, r
 	}
 
 	return dr
-}
-
-func (a *MetaAdapter) ParseBids(dr *adapters.DemandResponse) (*adapters.DemandResponse, error) {
-	switch dr.Status {
-	case http.StatusNoContent:
-		return dr, nil
-	case http.StatusServiceUnavailable:
-		fallthrough
-	case http.StatusBadRequest:
-		fallthrough
-	case http.StatusUnauthorized:
-		fallthrough
-	case http.StatusForbidden:
-		return dr, fmt.Errorf("unauthorized request: %s", strconv.Itoa(dr.Status))
-	case http.StatusOK:
-		break
-	default:
-		return dr, fmt.Errorf("unexpected status code: %s", strconv.Itoa(dr.Status))
-	}
-
-	var bidResponse openrtb2.BidResponse
-	err := json.Unmarshal([]byte(dr.RawResponse), &bidResponse)
-	if err != nil {
-		return dr, err
-	}
-
-	seat := bidResponse.SeatBid[0]
-	bid := seat.Bid[0]
-
-	dr.Bid = &adapters.BidDemandResponse{
-		ID:       bid.ID,
-		ImpID:    bid.ImpID,
-		Price:    bid.Price,
-		Payload:  bid.AdM,
-		DemandID: adapter.MetaKey,
-		AdID:     bid.AdID,
-		SeatID:   seat.Seat,
-		LURL:     bid.LURL,
-		NURL:     bid.NURL,
-		BURL:     bid.BURL,
-	}
-
-	return dr, nil
 }
 
 // Builder builds a new instance of the Meta adapter for the given bidder with the given config.

--- a/internal/bidding/adapters/meta/meta_test.go
+++ b/internal/bidding/adapters/meta/meta_test.go
@@ -352,12 +352,14 @@ func TestMeta_ParseBids(t *testing.T) {
 			name: "ParseBids Success",
 			params: ParseBidsTestParams{
 				DemandsResponse: adapters.DemandResponse{
+					DemandID:    "meta",
 					Status:      200,
 					RawResponse: rawResponse,
 				},
 			},
 			want: ParseBidsTestOutput{
 				DemandResponse: adapters.DemandResponse{
+					DemandID:    "meta",
 					Status:      200,
 					RawResponse: rawResponse,
 					Bid: &adapters.BidDemandResponse{
@@ -378,12 +380,14 @@ func TestMeta_ParseBids(t *testing.T) {
 			name: "ParseBids Bad Request",
 			params: ParseBidsTestParams{
 				DemandsResponse: adapters.DemandResponse{
+					DemandID:    "meta",
 					Status:      400,
 					RawResponse: rawResponse,
 				},
 			},
 			want: ParseBidsTestOutput{
 				DemandResponse: adapters.DemandResponse{
+					DemandID:    "meta",
 					Status:      400,
 					RawResponse: rawResponse,
 				},
@@ -394,12 +398,14 @@ func TestMeta_ParseBids(t *testing.T) {
 			name: "ParseBids No Content",
 			params: ParseBidsTestParams{
 				DemandsResponse: adapters.DemandResponse{
+					DemandID:    "meta",
 					Status:      204,
 					RawResponse: rawResponse,
 				},
 			},
 			want: ParseBidsTestOutput{
 				DemandResponse: adapters.DemandResponse{
+					DemandID:    "meta",
 					Status:      204,
 					RawResponse: rawResponse,
 				},
@@ -408,13 +414,13 @@ func TestMeta_ParseBids(t *testing.T) {
 		},
 	}
 	for _, tC := range testCases {
-		response, err := adapter.ParseBids(&tC.params.DemandsResponse)
+		response, err := adapters.ParseDemandResponse(&adapter, &tC.params.DemandsResponse)
 		got := ParseBidsTestOutput{
 			DemandResponse: *response,
 			Err:            err,
 		}
 		if diff := cmp.Diff(tC.want, got, cmp.Comparer(compareErrors)); diff != "" {
-			t.Errorf("%s: adapter.ParseBids(ctx, %v) mismatch (-want, +got):\n%s", tC.name, tC.params.DemandsResponse, diff)
+			t.Errorf("%s: adapters.ParseDemandResponse(&adapter, ctx, %v) mismatch (-want, +got):\n%s", tC.name, tC.params.DemandsResponse, diff)
 		}
 	}
 }

--- a/internal/bidding/adapters/meta/meta_test.go
+++ b/internal/bidding/adapters/meta/meta_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/prebid/openrtb/v19/adcom1"
 	"github.com/prebid/openrtb/v19/openrtb2"
 
@@ -362,7 +363,7 @@ func TestMeta_ParseBids(t *testing.T) {
 					DemandID:    "meta",
 					Status:      200,
 					RawResponse: rawResponse,
-					Bid: &adapters.BidDemandResponse{
+					Bid: &adapters.NormalizedBid{
 						ID:       "0",
 						ImpID:    "6579ca7b-7e2c-48b6-8915-46efa6530fb5",
 						Price:    1.5,
@@ -419,7 +420,7 @@ func TestMeta_ParseBids(t *testing.T) {
 			DemandResponse: *response,
 			Err:            err,
 		}
-		if diff := cmp.Diff(tC.want, got, cmp.Comparer(compareErrors)); diff != "" {
+		if diff := cmp.Diff(tC.want, got, cmp.Comparer(compareErrors), cmpopts.IgnoreFields(adapters.NormalizedBid{}, "Ext")); diff != "" {
 			t.Errorf("%s: adapters.ParseDemandResponse(&adapter, ctx, %v) mismatch (-want, +got):\n%s", tC.name, tC.params.DemandsResponse, diff)
 		}
 	}

--- a/internal/bidding/adapters/mintegral/mintegral.go
+++ b/internal/bidding/adapters/mintegral/mintegral.go
@@ -8,7 +8,6 @@ import (
 	"fmt"
 	"io"
 	"net/http"
-	"strconv"
 
 	"github.com/gofrs/uuid/v5"
 	"github.com/prebid/openrtb/v19/adcom1"
@@ -177,53 +176,6 @@ func (a *MintegralAdapter) ExecuteRequest(ctx context.Context, client *http.Clie
 	dr.Status = httpResp.StatusCode
 
 	return dr
-}
-
-func (a *MintegralAdapter) ParseBids(dr *adapters.DemandResponse) (*adapters.DemandResponse, error) {
-	switch dr.Status {
-	case http.StatusNoContent:
-		return dr, nil
-	case http.StatusServiceUnavailable:
-		fallthrough
-	case http.StatusBadRequest:
-		fallthrough
-	case http.StatusUnauthorized:
-		fallthrough
-	case http.StatusForbidden:
-		return dr, fmt.Errorf("unauthorized request: %s", strconv.Itoa(dr.Status))
-	case http.StatusOK:
-		break
-	default:
-		return dr, fmt.Errorf("unexpected status code: %s", strconv.Itoa(dr.Status))
-	}
-
-	var bidResponse openrtb2.BidResponse
-	err := json.Unmarshal([]byte(dr.RawResponse), &bidResponse)
-	if err != nil {
-		return dr, err
-	}
-
-	if bidResponse.SeatBid == nil {
-		return dr, nil
-	}
-
-	seat := bidResponse.SeatBid[0]
-	bid := seat.Bid[0]
-
-	dr.Bid = &adapters.BidDemandResponse{
-		ID:       bid.ID,
-		ImpID:    bid.ImpID,
-		Price:    bid.Price,
-		Payload:  bid.AdM,
-		DemandID: adapter.MintegralKey,
-		AdID:     bid.AdID,
-		SeatID:   seat.Seat,
-		LURL:     bid.LURL,
-		NURL:     bid.NURL,
-		BURL:     bid.BURL,
-	}
-
-	return dr, nil
 }
 
 // Builder builds a new instance of the Mintegral adapter for the given bidder with the given config.

--- a/internal/bidding/adapters/mintegral/mintegral_test.go
+++ b/internal/bidding/adapters/mintegral/mintegral_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/prebid/openrtb/v19/adcom1"
 	"github.com/prebid/openrtb/v19/openrtb2"
 
@@ -368,7 +369,7 @@ func TestMintegral_ParseBids(t *testing.T) {
 					DemandID:    "mintegral",
 					Status:      200,
 					RawResponse: rawResponse,
-					Bid: &adapters.BidDemandResponse{
+					Bid: &adapters.NormalizedBid{
 						ID:       "0",
 						ImpID:    "6579ca7b-7e2c-48b6-8915-46efa6530fb5",
 						Price:    1.5,
@@ -425,7 +426,7 @@ func TestMintegral_ParseBids(t *testing.T) {
 			DemandResponse: *response,
 			Err:            err,
 		}
-		if diff := cmp.Diff(tC.want, got, cmp.Comparer(compareErrors)); diff != "" {
+		if diff := cmp.Diff(tC.want, got, cmp.Comparer(compareErrors), cmpopts.IgnoreFields(adapters.NormalizedBid{}, "Ext")); diff != "" {
 			t.Errorf("%s: adapters.ParseDemandResponse(&adapter, ctx, %v) mismatch (-want, +got):\n%s", tC.name, tC.params.DemandsResponse, diff)
 		}
 	}

--- a/internal/bidding/adapters/mintegral/mintegral_test.go
+++ b/internal/bidding/adapters/mintegral/mintegral_test.go
@@ -358,12 +358,14 @@ func TestMintegral_ParseBids(t *testing.T) {
 			name: "ParseBids Success",
 			params: ParseBidsTestParams{
 				DemandsResponse: adapters.DemandResponse{
+					DemandID:    "mintegral",
 					Status:      200,
 					RawResponse: rawResponse,
 				},
 			},
 			want: ParseBidsTestOutput{
 				DemandResponse: adapters.DemandResponse{
+					DemandID:    "mintegral",
 					Status:      200,
 					RawResponse: rawResponse,
 					Bid: &adapters.BidDemandResponse{
@@ -384,12 +386,14 @@ func TestMintegral_ParseBids(t *testing.T) {
 			name: "ParseBids Bad Request",
 			params: ParseBidsTestParams{
 				DemandsResponse: adapters.DemandResponse{
+					DemandID:    "mintegral",
 					Status:      400,
 					RawResponse: rawResponse,
 				},
 			},
 			want: ParseBidsTestOutput{
 				DemandResponse: adapters.DemandResponse{
+					DemandID:    "mintegral",
 					Status:      400,
 					RawResponse: rawResponse,
 				},
@@ -400,12 +404,14 @@ func TestMintegral_ParseBids(t *testing.T) {
 			name: "ParseBids No Content",
 			params: ParseBidsTestParams{
 				DemandsResponse: adapters.DemandResponse{
+					DemandID:    "mintegral",
 					Status:      204,
 					RawResponse: rawResponse,
 				},
 			},
 			want: ParseBidsTestOutput{
 				DemandResponse: adapters.DemandResponse{
+					DemandID:    "mintegral",
 					Status:      204,
 					RawResponse: rawResponse,
 				},
@@ -414,13 +420,13 @@ func TestMintegral_ParseBids(t *testing.T) {
 		},
 	}
 	for _, tC := range testCases {
-		response, err := adapter.ParseBids(&tC.params.DemandsResponse)
+		response, err := adapters.ParseDemandResponse(&adapter, &tC.params.DemandsResponse)
 		got := ParseBidsTestOutput{
 			DemandResponse: *response,
 			Err:            err,
 		}
 		if diff := cmp.Diff(tC.want, got, cmp.Comparer(compareErrors)); diff != "" {
-			t.Errorf("%s: adapter.ParseBids(ctx, %v) mismatch (-want, +got):\n%s", tC.name, tC.params.DemandsResponse, diff)
+			t.Errorf("%s: adapters.ParseDemandResponse(&adapter, ctx, %v) mismatch (-want, +got):\n%s", tC.name, tC.params.DemandsResponse, diff)
 		}
 	}
 }

--- a/internal/bidding/adapters/mobilefuse/mobilefuse.go
+++ b/internal/bidding/adapters/mobilefuse/mobilefuse.go
@@ -182,25 +182,6 @@ func (a *MobileFuseAdapter) ExecuteRequest(ctx context.Context, client *http.Cli
 	return dr
 }
 
-func (a *MobileFuseAdapter) EnrichOpenRTBBid(
-	dr *adapters.DemandResponse,
-	_ *openrtb2.BidResponse,
-	_ openrtb2.SeatBid,
-	bid openrtb2.Bid,
-) error {
-	if bid.Ext == nil {
-		return nil
-	}
-	var extParam map[string]any
-	if err := json.Unmarshal(bid.Ext, &extParam); err != nil {
-		return err
-	}
-	if signaldata, ok := extParam["signaldata"].(string); ok {
-		dr.Bid.Signaldata = signaldata
-	}
-	return nil
-}
-
 // Builder builds a new instance of the MobileFuse adapter for the given bidder with the given config.
 func Builder(cfg adapter.ProcessedConfigsMap, client *http.Client) (*adapters.Bidder, error) {
 	mobileFuseCfg := cfg[adapter.MobileFuseKey]

--- a/internal/bidding/adapters/mobilefuse/mobilefuse.go
+++ b/internal/bidding/adapters/mobilefuse/mobilefuse.go
@@ -9,7 +9,6 @@ import (
 	"io"
 	"net/http"
 	"slices"
-	"strconv"
 
 	"github.com/gofrs/uuid/v5"
 	"github.com/prebid/openrtb/v19/adcom1"
@@ -183,55 +182,23 @@ func (a *MobileFuseAdapter) ExecuteRequest(ctx context.Context, client *http.Cli
 	return dr
 }
 
-func (a *MobileFuseAdapter) ParseBids(dr *adapters.DemandResponse) (*adapters.DemandResponse, error) {
-	switch dr.Status {
-	case http.StatusNoContent:
-		return dr, nil
-	case http.StatusServiceUnavailable:
-		fallthrough
-	case http.StatusBadRequest:
-		fallthrough
-	case http.StatusUnauthorized:
-		fallthrough
-	case http.StatusForbidden:
-		return dr, fmt.Errorf("unauthorized request: %s", strconv.Itoa(dr.Status))
-	case http.StatusOK:
-		break
-	default:
-		return dr, fmt.Errorf("unexpected status code: %s", strconv.Itoa(dr.Status))
+func (a *MobileFuseAdapter) EnrichOpenRTBBid(
+	dr *adapters.DemandResponse,
+	_ *openrtb2.BidResponse,
+	_ openrtb2.SeatBid,
+	bid openrtb2.Bid,
+) error {
+	if bid.Ext == nil {
+		return nil
 	}
-
-	var bidResponse openrtb2.BidResponse
-	err := json.Unmarshal([]byte(dr.RawResponse), &bidResponse)
-	if err != nil {
-		return dr, err
-	}
-
-	seat := bidResponse.SeatBid[0]
-	bid := seat.Bid[0]
-
 	var extParam map[string]any
-	err = json.Unmarshal(bid.Ext, &extParam)
-	if err != nil {
-		return dr, err
+	if err := json.Unmarshal(bid.Ext, &extParam); err != nil {
+		return err
 	}
-	signaldata := extParam["signaldata"].(string)
-
-	dr.Bid = &adapters.BidDemandResponse{
-		ID:         bid.ID,
-		ImpID:      bid.ImpID,
-		Price:      bid.Price,
-		Payload:    bid.AdM,
-		Signaldata: signaldata,
-		DemandID:   adapter.MobileFuseKey,
-		AdID:       bid.AdID,
-		SeatID:     seat.Seat,
-		LURL:       bid.LURL,
-		NURL:       bid.NURL,
-		BURL:       bid.BURL,
+	if signaldata, ok := extParam["signaldata"].(string); ok {
+		dr.Bid.Signaldata = signaldata
 	}
-
-	return dr, nil
+	return nil
 }
 
 // Builder builds a new instance of the MobileFuse adapter for the given bidder with the given config.

--- a/internal/bidding/adapters/mobilefuse/mobilefuse_test.go
+++ b/internal/bidding/adapters/mobilefuse/mobilefuse_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/prebid/openrtb/v19/adcom1"
 	"github.com/prebid/openrtb/v19/openrtb2"
 
@@ -259,7 +260,7 @@ func TestMobileFuse_CreateRequest(t *testing.T) {
 			Request: request,
 			Err:     err,
 		}
-		if diff := cmp.Diff(tC.want, got, cmp.Comparer(compareErrors)); diff != "" {
+		if diff := cmp.Diff(tC.want, got, cmp.Comparer(compareErrors), cmpopts.IgnoreFields(adapters.NormalizedBid{}, "Ext")); diff != "" {
 			t.Errorf("%s: adapter.CreateRequest(ctx, %v, %v) mismatch (-want, +got):\n%s", tC.name, tC.params.BaseBidRequest, tC.params.AuctionRequest, diff)
 		}
 	}
@@ -445,7 +446,7 @@ func TestMobileFuse_ParseBids(t *testing.T) {
 					DemandID:    "mobilefuse",
 					Status:      200,
 					RawResponse: rawResponse,
-					Bid: &adapters.BidDemandResponse{
+					Bid: &adapters.NormalizedBid{
 						ID:         "9f21299b7b7b6ad7fe30226748c57abf_banner",
 						ImpID:      "1",
 						Price:      1.904,
@@ -503,7 +504,7 @@ func TestMobileFuse_ParseBids(t *testing.T) {
 			DemandResponse: *response,
 			Err:            err,
 		}
-		if diff := cmp.Diff(tC.want, got, cmp.Comparer(compareErrors)); diff != "" {
+		if diff := cmp.Diff(tC.want, got, cmp.Comparer(compareErrors), cmpopts.IgnoreFields(adapters.NormalizedBid{}, "Ext")); diff != "" {
 			t.Errorf("%s: adapters.ParseDemandResponse(&adapter, ctx, %v) mismatch (-want, +got):\n%s", tC.name, tC.params.DemandsResponse, diff)
 		}
 	}

--- a/internal/bidding/adapters/mobilefuse/mobilefuse_test.go
+++ b/internal/bidding/adapters/mobilefuse/mobilefuse_test.go
@@ -435,12 +435,14 @@ func TestMobileFuse_ParseBids(t *testing.T) {
 			name: "ParseBids Success",
 			params: ParseBidsTestParams{
 				DemandsResponse: adapters.DemandResponse{
+					DemandID:    "mobilefuse",
 					Status:      200,
 					RawResponse: rawResponse,
 				},
 			},
 			want: ParseBidsTestOutput{
 				DemandResponse: adapters.DemandResponse{
+					DemandID:    "mobilefuse",
 					Status:      200,
 					RawResponse: rawResponse,
 					Bid: &adapters.BidDemandResponse{
@@ -462,12 +464,14 @@ func TestMobileFuse_ParseBids(t *testing.T) {
 			name: "ParseBids Bad Request",
 			params: ParseBidsTestParams{
 				DemandsResponse: adapters.DemandResponse{
+					DemandID:    "mobilefuse",
 					Status:      400,
 					RawResponse: rawResponse,
 				},
 			},
 			want: ParseBidsTestOutput{
 				DemandResponse: adapters.DemandResponse{
+					DemandID:    "mobilefuse",
 					Status:      400,
 					RawResponse: rawResponse,
 				},
@@ -478,12 +482,14 @@ func TestMobileFuse_ParseBids(t *testing.T) {
 			name: "ParseBids No Conten",
 			params: ParseBidsTestParams{
 				DemandsResponse: adapters.DemandResponse{
+					DemandID:    "mobilefuse",
 					Status:      204,
 					RawResponse: rawResponse,
 				},
 			},
 			want: ParseBidsTestOutput{
 				DemandResponse: adapters.DemandResponse{
+					DemandID:    "mobilefuse",
 					Status:      204,
 					RawResponse: rawResponse,
 				},
@@ -492,13 +498,13 @@ func TestMobileFuse_ParseBids(t *testing.T) {
 		},
 	}
 	for _, tC := range testCases {
-		response, err := adapter.ParseBids(&tC.params.DemandsResponse)
+		response, err := adapters.ParseDemandResponse(&adapter, &tC.params.DemandsResponse)
 		got := ParseBidsTestOutput{
 			DemandResponse: *response,
 			Err:            err,
 		}
 		if diff := cmp.Diff(tC.want, got, cmp.Comparer(compareErrors)); diff != "" {
-			t.Errorf("%s: adapter.ParseBids(ctx, %v) mismatch (-want, +got):\n%s", tC.name, tC.params.DemandsResponse, diff)
+			t.Errorf("%s: adapters.ParseDemandResponse(&adapter, ctx, %v) mismatch (-want, +got):\n%s", tC.name, tC.params.DemandsResponse, diff)
 		}
 	}
 }

--- a/internal/bidding/adapters/moloco/moloco.go
+++ b/internal/bidding/adapters/moloco/moloco.go
@@ -5,10 +5,8 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
-	"fmt"
 	"io"
 	"net/http"
-	"strconv"
 
 	"github.com/gofrs/uuid/v5"
 	"github.com/prebid/openrtb/v19/adcom1"
@@ -217,54 +215,6 @@ func (a *MolocoAdapter) ExecuteRequest(ctx context.Context, client *http.Client,
 	dr.Status = httpResp.StatusCode
 
 	return dr
-}
-
-// ParseBids implements the BidderInterface.ParseBids method
-func (a *MolocoAdapter) ParseBids(dr *adapters.DemandResponse) (*adapters.DemandResponse, error) {
-	switch dr.Status {
-	case http.StatusNoContent:
-		return dr, nil
-	case http.StatusServiceUnavailable:
-		fallthrough
-	case http.StatusBadRequest:
-		fallthrough
-	case http.StatusUnauthorized:
-		fallthrough
-	case http.StatusForbidden:
-		return dr, fmt.Errorf("unauthorized request: %s", strconv.Itoa(dr.Status))
-	case http.StatusOK:
-		break
-	default:
-		return dr, fmt.Errorf("unexpected status code: %s", strconv.Itoa(dr.Status))
-	}
-
-	var bidResponse openrtb2.BidResponse
-	err := json.Unmarshal([]byte(dr.RawResponse), &bidResponse)
-	if err != nil {
-		return dr, err
-	}
-
-	if len(bidResponse.SeatBid) == 0 || len(bidResponse.SeatBid[0].Bid) == 0 {
-		return dr, errors.New("no seatbid or bid in response")
-	}
-
-	seat := bidResponse.SeatBid[0]
-	bid := seat.Bid[0]
-
-	dr.Bid = &adapters.BidDemandResponse{
-		ID:       bid.ID,
-		ImpID:    bid.ImpID,
-		Price:    bid.Price,
-		Payload:  bid.AdM,
-		DemandID: adapter.MolocoKey,
-		AdID:     bid.AdID,
-		SeatID:   seat.Seat,
-		LURL:     bid.LURL,
-		NURL:     bid.NURL,
-		BURL:     bid.BURL,
-	}
-
-	return dr, nil
 }
 
 // Builder builds a new instance of the Moloco adapter for the given bidder with the given config.

--- a/internal/bidding/adapters/moloco/moloco_test.go
+++ b/internal/bidding/adapters/moloco/moloco_test.go
@@ -337,7 +337,7 @@ func TestMoloco_ParseBids_Success(t *testing.T) {
 		RawResponse: `{"id":"test-response","seatbid":[{"seat":"moloco","bid":[{"id":"test-bid","impid":"test-imp","price":1.5,"adm":"<html>test ad</html>","adid":"test-ad-id","nurl":"http://test.com/nurl","burl":"http://test.com/burl","lurl":"http://test.com/lurl","ext":{"signaldata":"test-signal"}}]}]}`,
 	}
 
-	result, err := adapter.ParseBids(demandResponse)
+	result, err := adapters.ParseDemandResponse(&adapter, demandResponse)
 
 	if err != nil {
 		t.Errorf("Expected no error, got %v", err)
@@ -364,7 +364,7 @@ func TestMoloco_ParseBids_NoContent(t *testing.T) {
 		Status: 204,
 	}
 
-	result, err := adapter.ParseBids(demandResponse)
+	result, err := adapters.ParseDemandResponse(&adapter, demandResponse)
 
 	if err != nil {
 		t.Errorf("Expected no error, got %v", err)
@@ -381,7 +381,7 @@ func TestMoloco_ParseBids_Unauthorized(t *testing.T) {
 		Status: 401,
 	}
 
-	_, err := adapter.ParseBids(demandResponse)
+	_, err := adapters.ParseDemandResponse(&adapter, demandResponse)
 
 	if err == nil {
 		t.Error("Expected error for 401 status, got nil")
@@ -411,9 +411,9 @@ func TestMoloco_Builder(t *testing.T) {
 
 	// Test that adapter was created with correct configuration
 	wantAdapter := moloco.MolocoAdapter{
-		TagID:    "test-tag-id",
-		AppID:    "test-app-id",
-		APIKey:   "test-api-key",
+		TagID:  "test-tag-id",
+		AppID:  "test-app-id",
+		APIKey: "test-api-key",
 	}
 	wantBidder := &adapters.Bidder{
 		Adapter: &wantAdapter,

--- a/internal/bidding/adapters/parse.go
+++ b/internal/bidding/adapters/parse.go
@@ -1,0 +1,88 @@
+package adapters
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strconv"
+
+	"github.com/prebid/openrtb/v19/openrtb2"
+)
+
+// CustomBidParser is implemented by non-OpenRTB adapters that fully own
+// parsing RawResponse into Bid. Type-asserted by ParseDemandResponse.
+type CustomBidParser interface {
+	ParseBids(*DemandResponse) (*DemandResponse, error)
+}
+
+// OpenRTBBidEnricher is implemented by OpenRTB adapters that need extra
+// extraction after the default BidDemandResponse mapping.
+type OpenRTBBidEnricher interface {
+	EnrichOpenRTBBid(
+		dr *DemandResponse,
+		bidResp *openrtb2.BidResponse,
+		seat openrtb2.SeatBid,
+		bid openrtb2.Bid,
+	) error
+}
+
+// ParseDemandResponse unpacks a demand HTTP response into a bid DTO.
+// Custom parsers take precedence; otherwise the shared OpenRTB path runs,
+// optionally followed by an OpenRTB enricher.
+func ParseDemandResponse(adapter BidderInterface, dr *DemandResponse) (*DemandResponse, error) {
+	if dr == nil {
+		return nil, fmt.Errorf("nil demand response")
+	}
+
+	if p, ok := adapter.(CustomBidParser); ok {
+		return p.ParseBids(dr)
+	}
+
+	return parseOpenRTBBids(adapter, dr)
+}
+
+func parseOpenRTBBids(adapter BidderInterface, dr *DemandResponse) (*DemandResponse, error) {
+	switch dr.Status {
+	case http.StatusNoContent:
+		return dr, nil
+	case http.StatusServiceUnavailable, http.StatusBadRequest, http.StatusUnauthorized, http.StatusForbidden:
+		return dr, fmt.Errorf("unauthorized request: %s", strconv.Itoa(dr.Status))
+	case http.StatusOK:
+		// proceed
+	default:
+		return dr, fmt.Errorf("unexpected status code: %s", strconv.Itoa(dr.Status))
+	}
+
+	var bidResponse openrtb2.BidResponse
+	if err := json.Unmarshal([]byte(dr.RawResponse), &bidResponse); err != nil {
+		return dr, err
+	}
+
+	if len(bidResponse.SeatBid) == 0 || len(bidResponse.SeatBid[0].Bid) == 0 {
+		return dr, nil
+	}
+
+	seat := bidResponse.SeatBid[0]
+	bid := seat.Bid[0]
+
+	dr.Bid = &BidDemandResponse{
+		ID:       bid.ID,
+		ImpID:    bid.ImpID,
+		Price:    bid.Price,
+		Payload:  bid.AdM,
+		DemandID: dr.DemandID,
+		AdID:     bid.AdID,
+		SeatID:   seat.Seat,
+		LURL:     bid.LURL,
+		NURL:     bid.NURL,
+		BURL:     bid.BURL,
+	}
+
+	if e, ok := adapter.(OpenRTBBidEnricher); ok {
+		if err := e.EnrichOpenRTBBid(dr, &bidResponse, seat, bid); err != nil {
+			return dr, err
+		}
+	}
+
+	return dr, nil
+}

--- a/internal/bidding/adapters/parse.go
+++ b/internal/bidding/adapters/parse.go
@@ -16,7 +16,9 @@ type CustomBidParser interface {
 }
 
 // OpenRTBBidEnricher is implemented by OpenRTB adapters that need extra
-// extraction after the default NormalizedBid mapping.
+// extraction after the default NormalizedBid mapping (e.g. TaurusX payload
+// from BidResponse.ext). Common bid.ext fields like signaldata are handled
+// by the shared parser.
 type OpenRTBBidEnricher interface {
 	EnrichOpenRTBBid(
 		dr *DemandResponse,
@@ -65,18 +67,24 @@ func parseOpenRTBBids(adapter BidderInterface, dr *DemandResponse) (*DemandRespo
 	seat := bidResponse.SeatBid[0]
 	bid := seat.Bid[0]
 
+	signaldata, err := signaldataFromBidExt(bid.Ext)
+	if err != nil {
+		return dr, err
+	}
+
 	dr.Bid = &NormalizedBid{
-		ID:       bid.ID,
-		ImpID:    bid.ImpID,
-		Price:    bid.Price,
-		Payload:  bid.AdM,
-		DemandID: dr.DemandID,
-		AdID:     bid.AdID,
-		SeatID:   seat.Seat,
-		LURL:     bid.LURL,
-		NURL:     bid.NURL,
-		BURL:     bid.BURL,
-		Ext:      bid.Ext,
+		ID:         bid.ID,
+		ImpID:      bid.ImpID,
+		Price:      bid.Price,
+		Payload:    bid.AdM,
+		Signaldata: signaldata,
+		DemandID:   dr.DemandID,
+		AdID:       bid.AdID,
+		SeatID:     seat.Seat,
+		LURL:       bid.LURL,
+		NURL:       bid.NURL,
+		BURL:       bid.BURL,
+		Ext:        bid.Ext,
 	}
 
 	if e, ok := adapter.(OpenRTBBidEnricher); ok {
@@ -86,4 +94,17 @@ func parseOpenRTBBids(adapter BidderInterface, dr *DemandResponse) (*DemandRespo
 	}
 
 	return dr, nil
+}
+
+func signaldataFromBidExt(ext json.RawMessage) (string, error) {
+	if len(ext) == 0 {
+		return "", nil
+	}
+	var bidExt struct {
+		Signaldata string `json:"signaldata"`
+	}
+	if err := json.Unmarshal(ext, &bidExt); err != nil {
+		return "", err
+	}
+	return bidExt.Signaldata, nil
 }

--- a/internal/bidding/adapters/parse.go
+++ b/internal/bidding/adapters/parse.go
@@ -16,7 +16,7 @@ type CustomBidParser interface {
 }
 
 // OpenRTBBidEnricher is implemented by OpenRTB adapters that need extra
-// extraction after the default BidDemandResponse mapping.
+// extraction after the default NormalizedBid mapping.
 type OpenRTBBidEnricher interface {
 	EnrichOpenRTBBid(
 		dr *DemandResponse,
@@ -65,7 +65,7 @@ func parseOpenRTBBids(adapter BidderInterface, dr *DemandResponse) (*DemandRespo
 	seat := bidResponse.SeatBid[0]
 	bid := seat.Bid[0]
 
-	dr.Bid = &BidDemandResponse{
+	dr.Bid = &NormalizedBid{
 		ID:       bid.ID,
 		ImpID:    bid.ImpID,
 		Price:    bid.Price,
@@ -76,6 +76,7 @@ func parseOpenRTBBids(adapter BidderInterface, dr *DemandResponse) (*DemandRespo
 		LURL:     bid.LURL,
 		NURL:     bid.NURL,
 		BURL:     bid.BURL,
+		Ext:      bid.Ext,
 	}
 
 	if e, ok := adapter.(OpenRTBBidEnricher); ok {

--- a/internal/bidding/adapters/parse.go
+++ b/internal/bidding/adapters/parse.go
@@ -32,16 +32,16 @@ type OpenRTBBidEnricher interface {
 // ParseDemandResponse unpacks a demand HTTP response into a bid DTO.
 // Custom parsers take precedence; otherwise the shared OpenRTB path runs,
 // optionally followed by an OpenRTB enricher.
-func ParseDemandResponse(adapter BidderInterface, dr *DemandResponse) (*DemandResponse, error) {
+func ParseDemandResponse(bidder BidderInterface, dr *DemandResponse) (*DemandResponse, error) {
 	if dr == nil {
 		return nil, fmt.Errorf("nil demand response")
 	}
 
-	if p, ok := adapter.(CustomBidParser); ok {
+	if p, ok := bidder.(CustomBidParser); ok {
 		return p.ParseBids(dr)
 	}
 
-	return parseOpenRTBBids(adapter, dr)
+	return parseOpenRTBBids(bidder, dr)
 }
 
 func parseOpenRTBBids(adapter BidderInterface, dr *DemandResponse) (*DemandResponse, error) {

--- a/internal/bidding/adapters/parse.go
+++ b/internal/bidding/adapters/parse.go
@@ -3,6 +3,7 @@ package adapters
 import (
 	"encoding/json"
 	"fmt"
+	"log"
 	"net/http"
 	"strconv"
 
@@ -67,17 +68,12 @@ func parseOpenRTBBids(adapter BidderInterface, dr *DemandResponse) (*DemandRespo
 	seat := bidResponse.SeatBid[0]
 	bid := seat.Bid[0]
 
-	signaldata, err := signaldataFromBidExt(bid.Ext)
-	if err != nil {
-		return dr, err
-	}
-
 	dr.Bid = &NormalizedBid{
 		ID:         bid.ID,
 		ImpID:      bid.ImpID,
 		Price:      bid.Price,
 		Payload:    bid.AdM,
-		Signaldata: signaldata,
+		Signaldata: signaldataFromBidExt(bid.Ext),
 		DemandID:   dr.DemandID,
 		AdID:       bid.AdID,
 		SeatID:     seat.Seat,
@@ -96,15 +92,16 @@ func parseOpenRTBBids(adapter BidderInterface, dr *DemandResponse) (*DemandRespo
 	return dr, nil
 }
 
-func signaldataFromBidExt(ext json.RawMessage) (string, error) {
+func signaldataFromBidExt(ext json.RawMessage) string {
 	if len(ext) == 0 {
-		return "", nil
+		return ""
 	}
 	var bidExt struct {
 		Signaldata string `json:"signaldata"`
 	}
 	if err := json.Unmarshal(ext, &bidExt); err != nil {
-		return "", err
+		log.Printf("failed to extract signaldata from bid.ext: %v", err)
+		return ""
 	}
-	return bidExt.Signaldata, nil
+	return bidExt.Signaldata
 }

--- a/internal/bidding/adapters/parse_test.go
+++ b/internal/bidding/adapters/parse_test.go
@@ -202,6 +202,19 @@ func TestParseDemandResponse_invalidJSON(t *testing.T) {
 	}
 }
 
+func TestParseDemandResponse_nilDemandResponse(t *testing.T) {
+	got, err := adapters.ParseDemandResponse(stubAdapter{}, nil)
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if err.Error() != "nil demand response" {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != nil {
+		t.Fatalf("expected nil result, got %+v", got)
+	}
+}
+
 func TestParseDemandResponse_callsEnricher(t *testing.T) {
 	raw, _ := json.Marshal(openrtb2.BidResponse{
 		SeatBid: []openrtb2.SeatBid{{

--- a/internal/bidding/adapters/parse_test.go
+++ b/internal/bidding/adapters/parse_test.go
@@ -1,0 +1,180 @@
+package adapters_test
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"testing"
+
+	"github.com/prebid/openrtb/v19/openrtb2"
+
+	"github.com/bidon-io/bidon-backend/internal/adapter"
+	"github.com/bidon-io/bidon-backend/internal/bidding/adapters"
+	"github.com/bidon-io/bidon-backend/internal/bidding/openrtb"
+	"github.com/bidon-io/bidon-backend/internal/sdkapi/schema"
+)
+
+type stubAdapter struct{}
+
+func (stubAdapter) CreateRequest(openrtb.BidRequest, *schema.AuctionRequest) (openrtb.BidRequest, error) {
+	return openrtb.BidRequest{}, nil
+}
+
+func (stubAdapter) ExecuteRequest(context.Context, *http.Client, openrtb.BidRequest) *adapters.DemandResponse {
+	return nil
+}
+
+type enricherAdapter struct {
+	stubAdapter
+	called bool
+}
+
+func (a *enricherAdapter) EnrichOpenRTBBid(
+	dr *adapters.DemandResponse,
+	_ *openrtb2.BidResponse,
+	_ openrtb2.SeatBid,
+	_ openrtb2.Bid,
+) error {
+	a.called = true
+	dr.Bid.Signaldata = "enriched"
+	return nil
+}
+
+type customParserAdapter struct {
+	stubAdapter
+}
+
+func (customParserAdapter) ParseBids(dr *adapters.DemandResponse) (*adapters.DemandResponse, error) {
+	dr.Bid = &adapters.BidDemandResponse{
+		DemandID: adapter.ZmaticooKey,
+		Payload:  "custom",
+		Price:    1.23,
+	}
+	return dr, nil
+}
+
+func TestParseDemandResponse_mapsOpenRTBBid(t *testing.T) {
+	raw, _ := json.Marshal(openrtb2.BidResponse{
+		ID: "resp-1",
+		SeatBid: []openrtb2.SeatBid{{
+			Seat: "seat-1",
+			Bid: []openrtb2.Bid{{
+				ID:    "bid-1",
+				ImpID: "imp-1",
+				Price: 2.5,
+				AdM:   "<ad>",
+				AdID:  "ad-1",
+				LURL:  "https://l",
+				NURL:  "https://n",
+				BURL:  "https://b",
+			}},
+		}},
+	})
+
+	dr := &adapters.DemandResponse{
+		DemandID:    adapter.VungleKey,
+		Status:      http.StatusOK,
+		RawResponse: string(raw),
+	}
+
+	got, err := adapters.ParseDemandResponse(stubAdapter{}, dr)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got.Bid == nil {
+		t.Fatal("expected bid")
+	}
+	bid := got.Bid
+	if bid.ID != "bid-1" || bid.ImpID != "imp-1" || bid.Price != 2.5 || bid.Payload != "<ad>" {
+		t.Fatalf("unexpected bid fields: %+v", bid)
+	}
+	if bid.DemandID != adapter.VungleKey || bid.AdID != "ad-1" || bid.SeatID != "seat-1" {
+		t.Fatalf("unexpected ids: %+v", bid)
+	}
+	if bid.LURL != "https://l" || bid.NURL != "https://n" || bid.BURL != "https://b" {
+		t.Fatalf("unexpected urls: %+v", bid)
+	}
+}
+
+func TestParseDemandResponse_emptySeatBidIsNoBid(t *testing.T) {
+	raw, _ := json.Marshal(openrtb2.BidResponse{ID: "resp-1", SeatBid: []openrtb2.SeatBid{}})
+	dr := &adapters.DemandResponse{
+		DemandID:    adapter.MolocoKey,
+		Status:      http.StatusOK,
+		RawResponse: string(raw),
+	}
+
+	got, err := adapters.ParseDemandResponse(stubAdapter{}, dr)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got.Bid != nil {
+		t.Fatalf("expected no bid, got %+v", got.Bid)
+	}
+}
+
+func TestParseDemandResponse_noContent(t *testing.T) {
+	dr := &adapters.DemandResponse{Status: http.StatusNoContent}
+	got, err := adapters.ParseDemandResponse(stubAdapter{}, dr)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got.Bid != nil {
+		t.Fatalf("expected no bid")
+	}
+}
+
+func TestParseDemandResponse_unauthorizedStatuses(t *testing.T) {
+	for _, status := range []int{http.StatusBadRequest, http.StatusUnauthorized, http.StatusForbidden, http.StatusServiceUnavailable} {
+		_, err := adapters.ParseDemandResponse(stubAdapter{}, &adapters.DemandResponse{Status: status})
+		if err == nil {
+			t.Fatalf("expected error for status %d", status)
+		}
+	}
+}
+
+func TestParseDemandResponse_invalidJSON(t *testing.T) {
+	_, err := adapters.ParseDemandResponse(stubAdapter{}, &adapters.DemandResponse{
+		Status:      http.StatusOK,
+		RawResponse: "{not-json",
+	})
+	if err == nil {
+		t.Fatal("expected JSON error")
+	}
+}
+
+func TestParseDemandResponse_callsEnricher(t *testing.T) {
+	raw, _ := json.Marshal(openrtb2.BidResponse{
+		SeatBid: []openrtb2.SeatBid{{
+			Bid: []openrtb2.Bid{{ID: "bid-1", ImpID: "imp-1", Price: 1}},
+		}},
+	})
+	enricher := &enricherAdapter{}
+	dr := &adapters.DemandResponse{
+		DemandID:    adapter.YandexKey,
+		Status:      http.StatusOK,
+		RawResponse: string(raw),
+	}
+
+	got, err := adapters.ParseDemandResponse(enricher, dr)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !enricher.called {
+		t.Fatal("expected enricher to be called")
+	}
+	if got.Bid.Signaldata != "enriched" {
+		t.Fatalf("expected enriched signaldata, got %q", got.Bid.Signaldata)
+	}
+}
+
+func TestParseDemandResponse_customParser(t *testing.T) {
+	dr := &adapters.DemandResponse{Status: http.StatusOK, RawResponse: "ignored"}
+	got, err := adapters.ParseDemandResponse(customParserAdapter{}, dr)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got.Bid == nil || got.Bid.Payload != "custom" || got.Bid.Price != 1.23 {
+		t.Fatalf("unexpected custom bid: %+v", got.Bid)
+	}
+}

--- a/internal/bidding/adapters/parse_test.go
+++ b/internal/bidding/adapters/parse_test.go
@@ -36,7 +36,7 @@ func (a *enricherAdapter) EnrichOpenRTBBid(
 	_ openrtb2.Bid,
 ) error {
 	a.called = true
-	dr.Bid.Signaldata = "enriched"
+	dr.Bid.Payload = "enriched"
 	return nil
 }
 
@@ -99,7 +99,7 @@ func TestParseDemandResponse_mapsOpenRTBBid(t *testing.T) {
 	}
 }
 
-func TestParseDemandResponse_preservesBidExt(t *testing.T) {
+func TestParseDemandResponse_extractsSignaldataAndPreservesBidExt(t *testing.T) {
 	ext := json.RawMessage(`{"signaldata":"x","rendering":{"creative":{"type":"vast"}}}`)
 	raw, _ := json.Marshal(openrtb2.BidResponse{
 		SeatBid: []openrtb2.SeatBid{{
@@ -115,6 +115,9 @@ func TestParseDemandResponse_preservesBidExt(t *testing.T) {
 	got, err := adapters.ParseDemandResponse(stubAdapter{}, dr)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
+	}
+	if got.Bid.Signaldata != "x" {
+		t.Fatalf("expected Signaldata %q, got %q", "x", got.Bid.Signaldata)
 	}
 	if string(got.Bid.Ext) != string(ext) {
 		t.Fatalf("expected Ext %s, got %s", string(ext), string(got.Bid.Ext))
@@ -188,8 +191,8 @@ func TestParseDemandResponse_callsEnricher(t *testing.T) {
 	if !enricher.called {
 		t.Fatal("expected enricher to be called")
 	}
-	if got.Bid.Signaldata != "enriched" {
-		t.Fatalf("expected enriched signaldata, got %q", got.Bid.Signaldata)
+	if got.Bid.Payload != "enriched" {
+		t.Fatalf("expected enriched payload, got %q", got.Bid.Payload)
 	}
 }
 

--- a/internal/bidding/adapters/parse_test.go
+++ b/internal/bidding/adapters/parse_test.go
@@ -124,6 +124,37 @@ func TestParseDemandResponse_extractsSignaldataAndPreservesBidExt(t *testing.T) 
 	}
 }
 
+func TestParseDemandResponse_malformedBidExtLeavesSignaldataEmpty(t *testing.T) {
+	ext := json.RawMessage(`{"signaldata":123}`)
+	raw, _ := json.Marshal(openrtb2.BidResponse{
+		SeatBid: []openrtb2.SeatBid{{
+			Bid: []openrtb2.Bid{{ID: "bid-1", ImpID: "imp-1", Price: 1.5, AdM: "<ad>", Ext: ext}},
+		}},
+	})
+	dr := &adapters.DemandResponse{
+		DemandID:    adapter.AdikteevKey,
+		Status:      http.StatusOK,
+		RawResponse: string(raw),
+	}
+
+	got, err := adapters.ParseDemandResponse(stubAdapter{}, dr)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got.Bid == nil {
+		t.Fatal("expected bid to be kept")
+	}
+	if got.Bid.Signaldata != "" {
+		t.Fatalf("expected empty Signaldata, got %q", got.Bid.Signaldata)
+	}
+	if got.Bid.Price != 1.5 || got.Bid.Payload != "<ad>" {
+		t.Fatalf("expected bid fields to be preserved, got %+v", got.Bid)
+	}
+	if string(got.Bid.Ext) != string(ext) {
+		t.Fatalf("expected Ext %s, got %s", string(ext), string(got.Bid.Ext))
+	}
+}
+
 func TestParseDemandResponse_emptySeatBidIsNoBid(t *testing.T) {
 	raw, _ := json.Marshal(openrtb2.BidResponse{ID: "resp-1", SeatBid: []openrtb2.SeatBid{}})
 	dr := &adapters.DemandResponse{

--- a/internal/bidding/adapters/parse_test.go
+++ b/internal/bidding/adapters/parse_test.go
@@ -45,7 +45,7 @@ type customParserAdapter struct {
 }
 
 func (customParserAdapter) ParseBids(dr *adapters.DemandResponse) (*adapters.DemandResponse, error) {
-	dr.Bid = &adapters.BidDemandResponse{
+	dr.Bid = &adapters.NormalizedBid{
 		DemandID: adapter.ZmaticooKey,
 		Payload:  "custom",
 		Price:    1.23,
@@ -93,6 +93,31 @@ func TestParseDemandResponse_mapsOpenRTBBid(t *testing.T) {
 	}
 	if bid.LURL != "https://l" || bid.NURL != "https://n" || bid.BURL != "https://b" {
 		t.Fatalf("unexpected urls: %+v", bid)
+	}
+	if bid.Ext != nil {
+		t.Fatalf("expected nil Ext, got %s", string(bid.Ext))
+	}
+}
+
+func TestParseDemandResponse_preservesBidExt(t *testing.T) {
+	ext := json.RawMessage(`{"signaldata":"x","rendering":{"creative":{"type":"vast"}}}`)
+	raw, _ := json.Marshal(openrtb2.BidResponse{
+		SeatBid: []openrtb2.SeatBid{{
+			Bid: []openrtb2.Bid{{ID: "bid-1", ImpID: "imp-1", Price: 1, Ext: ext}},
+		}},
+	})
+	dr := &adapters.DemandResponse{
+		DemandID:    adapter.AdikteevKey,
+		Status:      http.StatusOK,
+		RawResponse: string(raw),
+	}
+
+	got, err := adapters.ParseDemandResponse(stubAdapter{}, dr)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if string(got.Bid.Ext) != string(ext) {
+		t.Fatalf("expected Ext %s, got %s", string(ext), string(got.Bid.Ext))
 	}
 }
 

--- a/internal/bidding/adapters/parse_test.go
+++ b/internal/bidding/adapters/parse_test.go
@@ -192,6 +192,20 @@ func TestParseDemandResponse_unauthorizedStatuses(t *testing.T) {
 	}
 }
 
+func TestParseDemandResponse_unexpectedStatus(t *testing.T) {
+	dr := &adapters.DemandResponse{Status: http.StatusInternalServerError}
+	got, err := adapters.ParseDemandResponse(stubAdapter{}, dr)
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if err.Error() != "unexpected status code: 500" {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != dr {
+		t.Fatalf("expected demand response to be returned, got %+v", got)
+	}
+}
+
 func TestParseDemandResponse_invalidJSON(t *testing.T) {
 	_, err := adapters.ParseDemandResponse(stubAdapter{}, &adapters.DemandResponse{
 		Status:      http.StatusOK,

--- a/internal/bidding/adapters/startio/startio.go
+++ b/internal/bidding/adapters/startio/startio.go
@@ -9,7 +9,6 @@ import (
 	"io"
 	"net/http"
 	"net/url"
-	"strconv"
 
 	"github.com/gofrs/uuid/v5"
 	"github.com/prebid/openrtb/v19/adcom1"
@@ -251,53 +250,6 @@ func (a *Adapter) ExecuteRequest(ctx context.Context, client *http.Client, reque
 	dr.Status = httpResp.StatusCode
 
 	return dr
-}
-
-// ParseBids implements the BidderInterface.ParseBids method.
-func (a *Adapter) ParseBids(dr *adapters.DemandResponse) (*adapters.DemandResponse, error) {
-	switch dr.Status {
-	case http.StatusNoContent:
-		return dr, nil
-	case http.StatusServiceUnavailable:
-		fallthrough
-	case http.StatusBadRequest:
-		fallthrough
-	case http.StatusUnauthorized:
-		fallthrough
-	case http.StatusForbidden:
-		return dr, fmt.Errorf("unauthorized request: %s", strconv.Itoa(dr.Status))
-	case http.StatusOK:
-		// proceed
-	default:
-		return dr, fmt.Errorf("unexpected status code: %s", strconv.Itoa(dr.Status))
-	}
-
-	var bidResponse openrtb2.BidResponse
-	if err := json.Unmarshal([]byte(dr.RawResponse), &bidResponse); err != nil {
-		return dr, err
-	}
-
-	if len(bidResponse.SeatBid) == 0 || len(bidResponse.SeatBid[0].Bid) == 0 {
-		return dr, errors.New("no seatbid or bid in response")
-	}
-
-	seat := bidResponse.SeatBid[0]
-	bid := seat.Bid[0]
-
-	dr.Bid = &adapters.BidDemandResponse{
-		ID:       bid.ID,
-		ImpID:    bid.ImpID,
-		Price:    bid.Price,
-		Payload:  bid.AdM,
-		DemandID: adapter.StartIOKey,
-		AdID:     bid.AdID,
-		SeatID:   seat.Seat,
-		LURL:     bid.LURL,
-		NURL:     bid.NURL,
-		BURL:     bid.BURL,
-	}
-
-	return dr, nil
 }
 
 // Builder constructs a bidder for Start.io based on processed configuration.

--- a/internal/bidding/adapters/startio/startio_test.go
+++ b/internal/bidding/adapters/startio/startio_test.go
@@ -39,10 +39,10 @@ func buildAdapter() startio.Adapter {
 
 func buildBidRequest() openrtb.BidRequest {
 	return openrtb.BidRequest{
-		ID: "test-request-id",
+		ID:  "test-request-id",
 		App: &openrtb2.App{ID: ""},
 		Device: &openrtb2.Device{
-			UA: "test-user-agent",
+			UA:  "test-user-agent",
 			Geo: &openrtb2.Geo{Country: "USA"},
 		},
 	}
@@ -193,12 +193,12 @@ func TestAdapter_ExecuteRequest(t *testing.T) {
 func TestAdapter_ParseBids(t *testing.T) {
 	adapterInstance := buildAdapter()
 	resp := adapters.DemandResponse{
-		DemandID: adapter.StartIOKey,
-		Status:   http.StatusOK,
+		DemandID:    adapter.StartIOKey,
+		Status:      http.StatusOK,
 		RawResponse: `{"id":"response","seatbid":[{"seat":"startio","bid":[{"id":"bid-1","impid":"imp-1","price":1.23,"adm":"<html></html>","adid":"creative","nurl":"http://nurl","lurl":"http://lurl","burl":"http://burl"}]}]}`,
 	}
 
-	parsed, err := adapterInstance.ParseBids(&resp)
+	parsed, err := adapters.ParseDemandResponse(&adapterInstance, &resp)
 	if err != nil {
 		t.Fatalf("ParseBids error: %v", err)
 	}

--- a/internal/bidding/adapters/taurusx/taurusx.go
+++ b/internal/bidding/adapters/taurusx/taurusx.go
@@ -8,7 +8,6 @@ import (
 	"fmt"
 	"io"
 	"net/http"
-	"strconv"
 
 	"github.com/gofrs/uuid/v5"
 	"github.com/prebid/openrtb/v19/adcom1"
@@ -208,50 +207,20 @@ func (a *TaurusXAdapter) ExecuteRequest(ctx context.Context, client *http.Client
 	}
 	dr.RawResponse = string(respBody)
 
-	parsedDr, err := a.ParseBids(dr)
-	if err != nil {
-		dr.Error = err
-		return dr
-	}
-	return parsedDr
+	return dr
 }
 
-func (a *TaurusXAdapter) ParseBids(dr *adapters.DemandResponse) (*adapters.DemandResponse, error) {
-	switch dr.Status {
-	case http.StatusNoContent:
-		return dr, nil
-	case http.StatusServiceUnavailable:
-		fallthrough
-	case http.StatusBadRequest:
-		fallthrough
-	case http.StatusUnauthorized:
-		fallthrough
-	case http.StatusForbidden:
-		return dr, fmt.Errorf("unauthorized request: %s", strconv.Itoa(dr.Status))
-	case http.StatusOK:
-		break
-	default:
-		return dr, fmt.Errorf("unexpected status code: %s", strconv.Itoa(dr.Status))
-	}
-
-	var bidResponse openrtb2.BidResponse
-	err := json.Unmarshal([]byte(dr.RawResponse), &bidResponse)
-	if err != nil {
-		return dr, err
-	}
-
-	if len(bidResponse.SeatBid) == 0 || len(bidResponse.SeatBid[0].Bid) == 0 {
-		return dr, nil
-	}
-
-	seat := bidResponse.SeatBid[0]
-	bid := seat.Bid[0]
-
+func (a *TaurusXAdapter) EnrichOpenRTBBid(
+	dr *adapters.DemandResponse,
+	bidResp *openrtb2.BidResponse,
+	_ openrtb2.SeatBid,
+	_ openrtb2.Bid,
+) error {
 	payload := ""
-	if bidResponse.Ext != nil {
+	if bidResp.Ext != nil {
 		var extData map[string]interface{}
-		if err := json.Unmarshal(bidResponse.Ext, &extData); err != nil {
-			return dr, fmt.Errorf("failed to unmarshal bid response ext: %v", err)
+		if err := json.Unmarshal(bidResp.Ext, &extData); err != nil {
+			return fmt.Errorf("failed to unmarshal bid response ext: %v", err)
 		}
 		if payloadValue, exists := extData["payload"]; exists {
 			if payloadStr, ok := payloadValue.(string); ok {
@@ -259,21 +228,8 @@ func (a *TaurusXAdapter) ParseBids(dr *adapters.DemandResponse) (*adapters.Deman
 			}
 		}
 	}
-
-	dr.Bid = &adapters.BidDemandResponse{
-		ID:       bid.ID,
-		ImpID:    bid.ImpID,
-		Price:    bid.Price,
-		Payload:  payload,
-		DemandID: adapter.TaurusXKey,
-		AdID:     bid.AdID,
-		SeatID:   seat.Seat,
-		LURL:     bid.LURL,
-		NURL:     bid.NURL,
-		BURL:     bid.BURL,
-	}
-
-	return dr, nil
+	dr.Bid.Payload = payload
+	return nil
 }
 
 // Builder builds a new instance of the TaurusX adapter for the given bidder with the given config.

--- a/internal/bidding/adapters/taurusx/taurusx_test.go
+++ b/internal/bidding/adapters/taurusx/taurusx_test.go
@@ -89,7 +89,7 @@ func TestTaurusXAdapter_ParseBids_Success(t *testing.T) {
 		RawResponse: `{"id":"test-response","seatbid":[{"bid":[{"id":"test-bid","impid":"test-imp","price":1.5,"adid":"test-ad","nurl":"http://win.url","lurl":"http://loss.url"}],"seat":"test-seat"}],"ext":{"payload":"<html>test ad</html>"}}`,
 	}
 
-	result, err := taurusxAdapter.ParseBids(dr)
+	result, err := adapters.ParseDemandResponse(taurusxAdapter, dr)
 	if err != nil {
 		t.Errorf("ParseBids() error = %v", err)
 		return
@@ -124,7 +124,7 @@ func TestTaurusXAdapter_ParseBids_NoContent(t *testing.T) {
 		Status: http.StatusNoContent,
 	}
 
-	result, err := taurusxAdapter.ParseBids(dr)
+	result, err := adapters.ParseDemandResponse(taurusxAdapter, dr)
 	if err != nil {
 		t.Errorf("ParseBids() error = %v", err)
 		return
@@ -142,7 +142,7 @@ func TestTaurusXAdapter_ParseBids_Error(t *testing.T) {
 		Status: http.StatusBadRequest,
 	}
 
-	_, err := taurusxAdapter.ParseBids(dr)
+	_, err := adapters.ParseDemandResponse(taurusxAdapter, dr)
 	if err == nil {
 		t.Error("Expected error for bad request status")
 	}
@@ -156,7 +156,7 @@ func TestTaurusXAdapter_ParseBids_WithoutPayload(t *testing.T) {
 		RawResponse: `{"id":"test-response","seatbid":[{"bid":[{"id":"test-bid","impid":"test-imp","price":1.5,"adid":"test-ad","nurl":"http://win.url","lurl":"http://loss.url"}],"seat":"test-seat"}]}`,
 	}
 
-	result, err := taurusxAdapter.ParseBids(dr)
+	result, err := adapters.ParseDemandResponse(taurusxAdapter, dr)
 	if err != nil {
 		t.Errorf("ParseBids() error = %v", err)
 		return
@@ -181,7 +181,7 @@ func TestTaurusXAdapter_ParseBids_InvalidExtJSON(t *testing.T) {
 	}
 
 	// This should work fine since the ext JSON is valid, just doesn't have payload
-	result, err := taurusxAdapter.ParseBids(dr)
+	result, err := adapters.ParseDemandResponse(taurusxAdapter, dr)
 	if err != nil {
 		t.Errorf("ParseBids() error = %v", err)
 		return
@@ -206,7 +206,7 @@ func TestTaurusXAdapter_ParseBids_MalformedBidResponseJSON(t *testing.T) {
 		RawResponse: `{"id":"test-response","seatbid":[{"bid":[{"id":"test-bid","impid":"test-imp","price":1.5,"adid":"test-ad"}],"seat":"test-seat"}],"ext":{"malformed":json}}`,
 	}
 
-	_, err := taurusxAdapter.ParseBids(dr)
+	_, err := adapters.ParseDemandResponse(taurusxAdapter, dr)
 	if err == nil {
 		t.Error("Expected error for malformed JSON")
 		return
@@ -225,7 +225,7 @@ func TestTaurusXAdapter_ParseBids_MalformedExtJSON(t *testing.T) {
 		RawResponse: `{"id":"test-response","seatbid":[{"bid":[{"id":"test-bid","impid":"test-imp","price":1.5,"adid":"test-ad"}],"seat":"test-seat"}],"ext":"{\"malformed\":json}"}`,
 	}
 
-	_, err := taurusxAdapter.ParseBids(dr)
+	_, err := adapters.ParseDemandResponse(taurusxAdapter, dr)
 	if err == nil {
 		t.Error("Expected error for malformed ext JSON")
 		return
@@ -244,7 +244,7 @@ func TestTaurusXAdapter_ParseBids_PayloadNotString(t *testing.T) {
 		RawResponse: `{"id":"test-response","seatbid":[{"bid":[{"id":"test-bid","impid":"test-imp","price":1.5,"adid":"test-ad"}],"seat":"test-seat"}],"ext":{"payload":123}}`,
 	}
 
-	result, err := taurusxAdapter.ParseBids(dr)
+	result, err := adapters.ParseDemandResponse(taurusxAdapter, dr)
 	if err != nil {
 		t.Errorf("ParseBids() error = %v", err)
 		return
@@ -299,7 +299,7 @@ func TestTaurusXAdapter_ParseBids_RealTaurusXResponse(t *testing.T) {
 		}`,
 	}
 
-	result, err := taurusxAdapter.ParseBids(dr)
+	result, err := adapters.ParseDemandResponse(taurusxAdapter, dr)
 	if err != nil {
 		t.Errorf("ParseBids() error = %v", err)
 		return

--- a/internal/bidding/adapters/vkads/vkads.go
+++ b/internal/bidding/adapters/vkads/vkads.go
@@ -8,7 +8,6 @@ import (
 	"fmt"
 	"io"
 	"net/http"
-	"strconv"
 
 	"github.com/gofrs/uuid/v5"
 	"github.com/prebid/openrtb/v19/adcom1"
@@ -159,48 +158,6 @@ func (a *VKAdsAdapter) ExecuteRequest(ctx context.Context, client *http.Client, 
 	dr.Status = httpResp.StatusCode
 
 	return dr
-}
-
-func (a *VKAdsAdapter) ParseBids(dr *adapters.DemandResponse) (*adapters.DemandResponse, error) {
-	switch dr.Status {
-	case http.StatusNoContent:
-		return dr, nil
-	case http.StatusServiceUnavailable:
-		fallthrough
-	case http.StatusBadRequest:
-		fallthrough
-	case http.StatusUnauthorized:
-		fallthrough
-	case http.StatusForbidden:
-		return dr, fmt.Errorf("unauthorized request: %s", strconv.Itoa(dr.Status))
-	case http.StatusOK:
-		break
-	default:
-		return dr, fmt.Errorf("unexpected status code: %s", strconv.Itoa(dr.Status))
-	}
-
-	var bidResponse openrtb.BidResponse
-	err := json.Unmarshal([]byte(dr.RawResponse), &bidResponse)
-	if err != nil {
-		return dr, err
-	}
-
-	seat := bidResponse.SeatBid[0]
-	bid := seat.Bid[0]
-
-	dr.Bid = &adapters.BidDemandResponse{
-		ID:       bid.ID,
-		ImpID:    bid.ImpID,
-		Price:    bid.Price,
-		DemandID: adapter.VKAdsKey,
-		AdID:     bid.AdID,
-		SeatID:   seat.Seat,
-		LURL:     bid.LURL,
-		NURL:     bid.NURL,
-		BURL:     bid.BURL,
-	}
-
-	return dr, nil
 }
 
 // Builder builds a new instance of the VKAds adapter for the given bidder with the given config.

--- a/internal/bidding/adapters/vkads/vkads_test.go
+++ b/internal/bidding/adapters/vkads/vkads_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/prebid/openrtb/v19/adcom1"
 	"github.com/prebid/openrtb/v19/openrtb2"
 
@@ -252,7 +253,7 @@ func TestVKAds_CreateRequest(t *testing.T) {
 			Request: request,
 			Err:     err,
 		}
-		if diff := cmp.Diff(tC.want, got, cmp.Comparer(compareErrors)); diff != "" {
+		if diff := cmp.Diff(tC.want, got, cmp.Comparer(compareErrors), cmpopts.IgnoreFields(adapters.NormalizedBid{}, "Ext")); diff != "" {
 			t.Errorf("%s: adapter.CreateRequest(ctx, %v, %v) mismatch (-want, +got):\n%s", tC.name, tC.params.BaseBidRequest, tC.params.AuctionRequest, diff)
 		}
 	}
@@ -376,7 +377,7 @@ func TestVKAds_ParseBids(t *testing.T) {
 					DemandID:    adapter.VKAdsKey,
 					Status:      200,
 					RawResponse: rawResponse,
-					Bid: &adapters.BidDemandResponse{
+					Bid: &adapters.NormalizedBid{
 						ID:       "2:1::669e29a737559894",
 						ImpID:    "7703af66-0ec1-475f-b5a8-eda9d65c44e6",
 						Price:    1.5,
@@ -433,7 +434,7 @@ func TestVKAds_ParseBids(t *testing.T) {
 			DemandResponse: *response,
 			Err:            err,
 		}
-		if diff := cmp.Diff(tC.want, got, cmp.Comparer(compareErrors)); diff != "" {
+		if diff := cmp.Diff(tC.want, got, cmp.Comparer(compareErrors), cmpopts.IgnoreFields(adapters.NormalizedBid{}, "Ext")); diff != "" {
 			t.Errorf("%s: adapters.ParseDemandResponse(&a, ctx, %v) mismatch (-want, +got):\n%s", tC.name, tC.params.DemandsResponse, diff)
 		}
 	}

--- a/internal/bidding/adapters/vkads/vkads_test.go
+++ b/internal/bidding/adapters/vkads/vkads_test.go
@@ -366,18 +366,21 @@ func TestVKAds_ParseBids(t *testing.T) {
 			name: "ParseBids Success",
 			params: ParseBidsTestParams{
 				DemandsResponse: adapters.DemandResponse{
+					DemandID:    adapter.VKAdsKey,
 					Status:      200,
 					RawResponse: rawResponse,
 				},
 			},
 			want: ParseBidsTestOutput{
 				DemandResponse: adapters.DemandResponse{
+					DemandID:    adapter.VKAdsKey,
 					Status:      200,
 					RawResponse: rawResponse,
 					Bid: &adapters.BidDemandResponse{
 						ID:       "2:1::669e29a737559894",
 						ImpID:    "7703af66-0ec1-475f-b5a8-eda9d65c44e6",
 						Price:    1.5,
+						Payload:  "adm",
 						DemandID: "vkads",
 						AdID:     "162456424",
 						LURL:     "https://rs.mail.ru",
@@ -391,12 +394,14 @@ func TestVKAds_ParseBids(t *testing.T) {
 			name: "ParseBids Bad Request",
 			params: ParseBidsTestParams{
 				DemandsResponse: adapters.DemandResponse{
+					DemandID:    adapter.VKAdsKey,
 					Status:      400,
 					RawResponse: rawResponse,
 				},
 			},
 			want: ParseBidsTestOutput{
 				DemandResponse: adapters.DemandResponse{
+					DemandID:    adapter.VKAdsKey,
 					Status:      400,
 					RawResponse: rawResponse,
 				},
@@ -407,12 +412,14 @@ func TestVKAds_ParseBids(t *testing.T) {
 			name: "ParseBids No Content",
 			params: ParseBidsTestParams{
 				DemandsResponse: adapters.DemandResponse{
+					DemandID:    adapter.VKAdsKey,
 					Status:      204,
 					RawResponse: rawResponse,
 				},
 			},
 			want: ParseBidsTestOutput{
 				DemandResponse: adapters.DemandResponse{
+					DemandID:    adapter.VKAdsKey,
 					Status:      204,
 					RawResponse: rawResponse,
 				},
@@ -421,13 +428,13 @@ func TestVKAds_ParseBids(t *testing.T) {
 		},
 	}
 	for _, tC := range testCases {
-		response, err := a.ParseBids(&tC.params.DemandsResponse)
+		response, err := adapters.ParseDemandResponse(&a, &tC.params.DemandsResponse)
 		got := ParseBidsTestOutput{
 			DemandResponse: *response,
 			Err:            err,
 		}
 		if diff := cmp.Diff(tC.want, got, cmp.Comparer(compareErrors)); diff != "" {
-			t.Errorf("%s: a.ParseBids(ctx, %v) mismatch (-want, +got):\n%s", tC.name, tC.params.DemandsResponse, diff)
+			t.Errorf("%s: adapters.ParseDemandResponse(&a, ctx, %v) mismatch (-want, +got):\n%s", tC.name, tC.params.DemandsResponse, diff)
 		}
 	}
 }

--- a/internal/bidding/adapters/vungle/vungle.go
+++ b/internal/bidding/adapters/vungle/vungle.go
@@ -8,7 +8,6 @@ import (
 	"fmt"
 	"io"
 	"net/http"
-	"strconv"
 
 	"github.com/gofrs/uuid/v5"
 	"github.com/prebid/openrtb/v19/adcom1"
@@ -172,49 +171,6 @@ func (a *VungleAdapter) ExecuteRequest(ctx context.Context, client *http.Client,
 	dr.Status = httpResp.StatusCode
 
 	return dr
-}
-
-func (a *VungleAdapter) ParseBids(dr *adapters.DemandResponse) (*adapters.DemandResponse, error) {
-	switch dr.Status {
-	case http.StatusNoContent:
-		return dr, nil
-	case http.StatusServiceUnavailable:
-		fallthrough
-	case http.StatusBadRequest:
-		fallthrough
-	case http.StatusUnauthorized:
-		fallthrough
-	case http.StatusForbidden:
-		return dr, fmt.Errorf("unauthorized request: %s", strconv.Itoa(dr.Status))
-	case http.StatusOK:
-		break
-	default:
-		return dr, fmt.Errorf("unexpected status code: %s", strconv.Itoa(dr.Status))
-	}
-
-	var bidResponse openrtb2.BidResponse
-	err := json.Unmarshal([]byte(dr.RawResponse), &bidResponse)
-	if err != nil {
-		return dr, err
-	}
-
-	seat := bidResponse.SeatBid[0]
-	bid := seat.Bid[0]
-
-	dr.Bid = &adapters.BidDemandResponse{
-		ID:       bid.ID,
-		ImpID:    bid.ImpID,
-		Price:    bid.Price,
-		Payload:  bid.AdM,
-		DemandID: adapter.VungleKey,
-		AdID:     bid.AdID,
-		SeatID:   seat.Seat,
-		LURL:     bid.LURL,
-		NURL:     bid.NURL,
-		BURL:     bid.BURL,
-	}
-
-	return dr, nil
 }
 
 // Builder builds a new instance of the Vungle adapter for the given bidder with the given config.

--- a/internal/bidding/adapters/vungle/vungle_test.go
+++ b/internal/bidding/adapters/vungle/vungle_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/prebid/openrtb/v19/adcom1"
 	"github.com/prebid/openrtb/v19/openrtb2"
 
@@ -364,7 +365,7 @@ func TestVungle_ParseBids(t *testing.T) {
 					DemandID:    "vungle",
 					Status:      200,
 					RawResponse: rawResponse,
-					Bid: &adapters.BidDemandResponse{
+					Bid: &adapters.NormalizedBid{
 						ID:       "0",
 						ImpID:    "6579ca7b-7e2c-48b6-8915-46efa6530fb5",
 						Price:    1.5,
@@ -421,7 +422,7 @@ func TestVungle_ParseBids(t *testing.T) {
 			DemandResponse: *response,
 			Err:            err,
 		}
-		if diff := cmp.Diff(tC.want, got, cmp.Comparer(compareErrors)); diff != "" {
+		if diff := cmp.Diff(tC.want, got, cmp.Comparer(compareErrors), cmpopts.IgnoreFields(adapters.NormalizedBid{}, "Ext")); diff != "" {
 			t.Errorf("%s: adapters.ParseDemandResponse(&adapter, ctx, %v) mismatch (-want, +got):\n%s", tC.name, tC.params.DemandsResponse, diff)
 		}
 	}

--- a/internal/bidding/adapters/vungle/vungle_test.go
+++ b/internal/bidding/adapters/vungle/vungle_test.go
@@ -354,12 +354,14 @@ func TestVungle_ParseBids(t *testing.T) {
 			name: "ParseBids Success",
 			params: ParseBidsTestParams{
 				DemandsResponse: adapters.DemandResponse{
+					DemandID:    "vungle",
 					Status:      200,
 					RawResponse: rawResponse,
 				},
 			},
 			want: ParseBidsTestOutput{
 				DemandResponse: adapters.DemandResponse{
+					DemandID:    "vungle",
 					Status:      200,
 					RawResponse: rawResponse,
 					Bid: &adapters.BidDemandResponse{
@@ -380,12 +382,14 @@ func TestVungle_ParseBids(t *testing.T) {
 			name: "ParseBids Bad Request",
 			params: ParseBidsTestParams{
 				DemandsResponse: adapters.DemandResponse{
+					DemandID:    "vungle",
 					Status:      400,
 					RawResponse: rawResponse,
 				},
 			},
 			want: ParseBidsTestOutput{
 				DemandResponse: adapters.DemandResponse{
+					DemandID:    "vungle",
 					Status:      400,
 					RawResponse: rawResponse,
 				},
@@ -396,12 +400,14 @@ func TestVungle_ParseBids(t *testing.T) {
 			name: "ParseBids No Content",
 			params: ParseBidsTestParams{
 				DemandsResponse: adapters.DemandResponse{
+					DemandID:    "vungle",
 					Status:      204,
 					RawResponse: rawResponse,
 				},
 			},
 			want: ParseBidsTestOutput{
 				DemandResponse: adapters.DemandResponse{
+					DemandID:    "vungle",
 					Status:      204,
 					RawResponse: rawResponse,
 				},
@@ -410,13 +416,13 @@ func TestVungle_ParseBids(t *testing.T) {
 		},
 	}
 	for _, tC := range testCases {
-		response, err := adapter.ParseBids(&tC.params.DemandsResponse)
+		response, err := adapters.ParseDemandResponse(&adapter, &tC.params.DemandsResponse)
 		got := ParseBidsTestOutput{
 			DemandResponse: *response,
 			Err:            err,
 		}
 		if diff := cmp.Diff(tC.want, got, cmp.Comparer(compareErrors)); diff != "" {
-			t.Errorf("%s: adapter.ParseBids(ctx, %v) mismatch (-want, +got):\n%s", tC.name, tC.params.DemandsResponse, diff)
+			t.Errorf("%s: adapters.ParseDemandResponse(&adapter, ctx, %v) mismatch (-want, +got):\n%s", tC.name, tC.params.DemandsResponse, diff)
 		}
 	}
 }

--- a/internal/bidding/adapters/yandex/yandex.go
+++ b/internal/bidding/adapters/yandex/yandex.go
@@ -184,26 +184,6 @@ func (a *YandexAdapter) ExecuteRequest(ctx context.Context, client *http.Client,
 	return dr
 }
 
-func (a *YandexAdapter) EnrichOpenRTBBid(
-	dr *adapters.DemandResponse,
-	_ *openrtb2.BidResponse,
-	_ openrtb2.SeatBid,
-	bid openrtb2.Bid,
-) error {
-	type BidExt struct {
-		SignalData string `json:"signaldata"`
-	}
-
-	var bidExt BidExt
-	if bid.Ext != nil {
-		if err := json.Unmarshal(bid.Ext, &bidExt); err != nil {
-			return err
-		}
-	}
-	dr.Bid.Signaldata = bidExt.SignalData
-	return nil
-}
-
 // Builder builds a new instance of the Yandex adapter for the given bidder with the given config.
 func Builder(cfg adapter.ProcessedConfigsMap, client *http.Client) (*adapters.Bidder, error) {
 	yandexCfg := cfg[adapter.YandexKey]

--- a/internal/bidding/adapters/yandex/yandex.go
+++ b/internal/bidding/adapters/yandex/yandex.go
@@ -5,10 +5,8 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
-	"fmt"
 	"io"
 	"net/http"
-	"strconv"
 
 	"github.com/gofrs/uuid/v5"
 	"github.com/prebid/openrtb/v19/adcom1"
@@ -186,42 +184,12 @@ func (a *YandexAdapter) ExecuteRequest(ctx context.Context, client *http.Client,
 	return dr
 }
 
-func (a *YandexAdapter) ParseBids(dr *adapters.DemandResponse) (*adapters.DemandResponse, error) {
-	switch dr.Status {
-	case http.StatusNoContent:
-		return dr, nil
-	case http.StatusServiceUnavailable:
-		fallthrough
-	case http.StatusBadRequest:
-		fallthrough
-	case http.StatusUnauthorized:
-		fallthrough
-	case http.StatusForbidden:
-		return dr, fmt.Errorf("unauthorized request: %s", strconv.Itoa(dr.Status))
-	case http.StatusOK:
-		break
-	default:
-		return dr, fmt.Errorf("unexpected status code: %s", strconv.Itoa(dr.Status))
-	}
-
-	var bidResponse openrtb2.BidResponse
-	err := json.Unmarshal([]byte(dr.RawResponse), &bidResponse)
-	if err != nil {
-		return dr, err
-	}
-
-	if bidResponse.SeatBid == nil || len(bidResponse.SeatBid) == 0 {
-		return dr, nil
-	}
-
-	seat := bidResponse.SeatBid[0]
-	if len(seat.Bid) == 0 {
-		return dr, nil
-	}
-
-	bid := seat.Bid[0]
-
-	// Extract signaldata from bid.ext
+func (a *YandexAdapter) EnrichOpenRTBBid(
+	dr *adapters.DemandResponse,
+	_ *openrtb2.BidResponse,
+	_ openrtb2.SeatBid,
+	bid openrtb2.Bid,
+) error {
 	type BidExt struct {
 		SignalData string `json:"signaldata"`
 	}
@@ -229,25 +197,11 @@ func (a *YandexAdapter) ParseBids(dr *adapters.DemandResponse) (*adapters.Demand
 	var bidExt BidExt
 	if bid.Ext != nil {
 		if err := json.Unmarshal(bid.Ext, &bidExt); err != nil {
-			return dr, err
+			return err
 		}
 	}
-
-	dr.Bid = &adapters.BidDemandResponse{
-		ID:         bid.ID,
-		ImpID:      bid.ImpID,
-		Price:      bid.Price,
-		Payload:    bid.AdM,
-		Signaldata: bidExt.SignalData,
-		DemandID:   adapter.YandexKey,
-		AdID:       bid.AdID,
-		SeatID:     seat.Seat,
-		LURL:       bid.LURL,
-		NURL:       bid.NURL,
-		BURL:       bid.BURL,
-	}
-
-	return dr, nil
+	dr.Bid.Signaldata = bidExt.SignalData
+	return nil
 }
 
 // Builder builds a new instance of the Yandex adapter for the given bidder with the given config.

--- a/internal/bidding/adapters/yandex/yandex_test.go
+++ b/internal/bidding/adapters/yandex/yandex_test.go
@@ -344,7 +344,7 @@ func TestYandex_ParseBids_Success(t *testing.T) {
 		Status:      http.StatusOK,
 	}
 
-	result, err := adpt.ParseBids(dr)
+	result, err := adapters.ParseDemandResponse(&adpt, dr)
 	if err != nil {
 		t.Fatalf("ParseBids() error = %v", err)
 	}
@@ -379,7 +379,7 @@ func TestYandex_ParseBids_NoContent(t *testing.T) {
 		Status:    http.StatusNoContent,
 	}
 
-	result, err := adpt.ParseBids(dr)
+	result, err := adapters.ParseDemandResponse(&adpt, dr)
 	if err != nil {
 		t.Fatalf("ParseBids() error = %v", err)
 	}
@@ -407,7 +407,7 @@ func TestYandex_ParseBids_ErrorStatuses(t *testing.T) {
 				Status:    status,
 			}
 
-			_, err := adpt.ParseBids(dr)
+			_, err := adapters.ParseDemandResponse(&adpt, dr)
 			if err == nil {
 				t.Errorf("Expected error for status %d, got nil", status)
 			}
@@ -433,7 +433,7 @@ func TestYandex_ParseBids_EmptySeatBid(t *testing.T) {
 		Status:      http.StatusOK,
 	}
 
-	result, err := adpt.ParseBids(dr)
+	result, err := adapters.ParseDemandResponse(&adpt, dr)
 	if err != nil {
 		t.Fatalf("ParseBids() error = %v", err)
 	}
@@ -453,7 +453,7 @@ func TestYandex_ParseBids_InvalidJSON(t *testing.T) {
 		Status:      http.StatusOK,
 	}
 
-	_, err := adpt.ParseBids(dr)
+	_, err := adapters.ParseDemandResponse(&adpt, dr)
 	if err == nil {
 		t.Error("Expected error for invalid JSON, got nil")
 	}

--- a/internal/bidding/adapters/zmaticoo/zmaticoo.go
+++ b/internal/bidding/adapters/zmaticoo/zmaticoo.go
@@ -229,7 +229,7 @@ func (a *ZmaticooAdapter) ParseBids(dr *adapters.DemandResponse) (*adapters.Dema
 		impID = dr.ImpID
 	}
 
-	dr.Bid = &adapters.BidDemandResponse{
+	dr.Bid = &adapters.NormalizedBid{
 		ID:       br.RequestID,
 		ImpID:    impID, // Zmaticoo response is not OpenRTB, so we get it from request
 		Price:    br.ECPM,

--- a/internal/bidding/adapters/zmaticoo/zmaticoo.go
+++ b/internal/bidding/adapters/zmaticoo/zmaticoo.go
@@ -187,13 +187,7 @@ func (a *ZmaticooAdapter) ExecuteRequest(ctx context.Context, client *http.Clien
 	}
 	dr.RawResponse = string(respBody)
 
-	parsedDr, err := a.ParseBids(dr)
-	if err != nil {
-		dr.Error = err
-		return dr
-	}
-
-	return parsedDr
+	return dr
 }
 
 func (a *ZmaticooAdapter) ParseBids(dr *adapters.DemandResponse) (*adapters.DemandResponse, error) {

--- a/internal/bidding/adapters/zmaticoo/zmaticoo_test.go
+++ b/internal/bidding/adapters/zmaticoo/zmaticoo_test.go
@@ -116,7 +116,7 @@ func TestZmaticooAdapter_ParseBids_Success(t *testing.T) {
 		}`,
 	}
 
-	result, err := zmaticooAdapter.ParseBids(dr)
+	result, err := adapters.ParseDemandResponse(zmaticooAdapter, dr)
 	if err != nil {
 		t.Errorf("ParseBids() error = %v", err)
 		return
@@ -159,7 +159,7 @@ func TestZmaticooAdapter_ParseBids_NoContent(t *testing.T) {
 		Status: http.StatusNoContent,
 	}
 
-	result, err := zmaticooAdapter.ParseBids(dr)
+	result, err := adapters.ParseDemandResponse(zmaticooAdapter, dr)
 	if err != nil {
 		t.Errorf("ParseBids() error = %v", err)
 		return
@@ -177,7 +177,7 @@ func TestZmaticooAdapter_ParseBids_ErrorStatus(t *testing.T) {
 		Status: http.StatusBadRequest,
 	}
 
-	_, err := zmaticooAdapter.ParseBids(dr)
+	_, err := adapters.ParseDemandResponse(zmaticooAdapter, dr)
 	if err == nil {
 		t.Error("Expected error for bad request status")
 	}
@@ -191,7 +191,7 @@ func TestZmaticooAdapter_ParseBids_FailedCode(t *testing.T) {
 		RawResponse: `{"code":1002,"msg":"Invalid token"}`,
 	}
 
-	_, err := zmaticooAdapter.ParseBids(dr)
+	_, err := adapters.ParseDemandResponse(zmaticooAdapter, dr)
 	if err == nil {
 		t.Error("Expected error for failed code response")
 		return
@@ -210,7 +210,7 @@ func TestZmaticooAdapter_ParseBids_MissingBidResult(t *testing.T) {
 		RawResponse: `{"code":1,"msg":"bid success"}`,
 	}
 
-	_, err := zmaticooAdapter.ParseBids(dr)
+	_, err := adapters.ParseDemandResponse(zmaticooAdapter, dr)
 	if err == nil {
 		t.Error("Expected error for missing bid_result")
 	}
@@ -253,12 +253,21 @@ func TestZmaticooAdapter_ExecuteRequest_Success(t *testing.T) {
 		t.Fatalf("Expected RawRequest/RawResponse to be set")
 	}
 
-	if dr.Bid == nil {
+	if dr.Bid != nil {
+		t.Fatalf("ExecuteRequest should not parse bids")
+	}
+
+	parsed, err := adapters.ParseDemandResponse(zmaticooAdapter, dr)
+	if err != nil {
+		t.Fatalf("ParseDemandResponse() error = %v", err)
+	}
+
+	if parsed.Bid == nil {
 		t.Fatalf("Expected bid to be present")
 	}
 
-	if dr.Bid.ImpID != "imp-1" {
-		t.Fatalf("Expected ImpID 'imp-1', got '%s'", dr.Bid.ImpID)
+	if parsed.Bid.ImpID != "imp-1" {
+		t.Fatalf("Expected ImpID 'imp-1', got '%s'", parsed.Bid.ImpID)
 	}
 
 	if !gotContentType || !gotOpenRTBVersion {

--- a/internal/bidding/bid_cacher.go
+++ b/internal/bidding/bid_cacher.go
@@ -63,6 +63,7 @@ type CachedBid struct {
 	LURL        string
 	NURL        string
 	BURL        string
+	Ext         json.RawMessage
 }
 
 func cachedBidFromDemandResponse(dr adapters.DemandResponse) CachedBid {
@@ -86,6 +87,7 @@ func cachedBidFromDemandResponse(dr adapters.DemandResponse) CachedBid {
 		LURL:        dr.Bid.LURL,
 		NURL:        dr.Bid.NURL,
 		BURL:        dr.Bid.BURL,
+		Ext:         dr.Bid.Ext,
 		Token:       dr.Token,
 	}
 }
@@ -97,7 +99,7 @@ func (cb CachedBid) toDemandResponse() adapters.DemandResponse {
 		RawRequest:  "",
 		RawResponse: "",
 		Status:      cb.Status,
-		Bid: &adapters.BidDemandResponse{
+		Bid: &adapters.NormalizedBid{
 			Payload:    cb.Payload,
 			Signaldata: cb.Signaldata,
 			ID:         cb.ID,
@@ -109,6 +111,7 @@ func (cb CachedBid) toDemandResponse() adapters.DemandResponse {
 			LURL:       cb.LURL,
 			NURL:       cb.NURL,
 			BURL:       cb.BURL,
+			Ext:        cb.Ext,
 		},
 		Error:       nil,
 		TagID:       cb.TagID,

--- a/internal/bidding/bid_cacher_test.go
+++ b/internal/bidding/bid_cacher_test.go
@@ -50,9 +50,9 @@ func TestBidCache_ApplyBidCache(t *testing.T) {
 		{
 			name: "no cache, has bids",
 			bids: []adapters.DemandResponse{
-				{DemandID: adapter.BidmachineKey, Bid: &adapters.BidDemandResponse{DemandID: adapter.BidmachineKey, Price: 1.0}},
-				{DemandID: adapter.ApplovinKey, Bid: &adapters.BidDemandResponse{DemandID: adapter.ApplovinKey, Price: 2.0}},
-				{DemandID: adapter.MetaKey, Bid: &adapters.BidDemandResponse{DemandID: adapter.MetaKey, Price: 3.0}},
+				{DemandID: adapter.BidmachineKey, Bid: &adapters.NormalizedBid{DemandID: adapter.BidmachineKey, Price: 1.0}},
+				{DemandID: adapter.ApplovinKey, Bid: &adapters.NormalizedBid{DemandID: adapter.ApplovinKey, Price: 2.0}},
+				{DemandID: adapter.MetaKey, Bid: &adapters.NormalizedBid{DemandID: adapter.MetaKey, Price: 3.0}},
 			},
 			cacheGet: bidding.Cache{},
 			cacheSet: bidding.Cache{
@@ -65,8 +65,8 @@ func TestBidCache_ApplyBidCache(t *testing.T) {
 				},
 			},
 			want: []adapters.DemandResponse{
-				{DemandID: adapter.BidmachineKey, Bid: &adapters.BidDemandResponse{DemandID: adapter.BidmachineKey, Price: 1.0}},
-				{DemandID: adapter.MetaKey, Bid: &adapters.BidDemandResponse{DemandID: adapter.MetaKey, Price: 3.0}},
+				{DemandID: adapter.BidmachineKey, Bid: &adapters.NormalizedBid{DemandID: adapter.BidmachineKey, Price: 1.0}},
+				{DemandID: adapter.MetaKey, Bid: &adapters.NormalizedBid{DemandID: adapter.MetaKey, Price: 3.0}},
 			},
 		},
 		{
@@ -96,7 +96,7 @@ func TestBidCache_ApplyBidCache(t *testing.T) {
 				},
 			},
 			want: []adapters.DemandResponse{
-				{DemandID: adapter.ApplovinKey, Bid: &adapters.BidDemandResponse{DemandID: adapter.ApplovinKey, Price: 2.0}},
+				{DemandID: adapter.ApplovinKey, Bid: &adapters.NormalizedBid{DemandID: adapter.ApplovinKey, Price: 2.0}},
 			},
 		},
 		{
@@ -118,7 +118,7 @@ func TestBidCache_ApplyBidCache(t *testing.T) {
 			},
 			cacheSet: bidding.Cache{},
 			want: []adapters.DemandResponse{
-				{DemandID: adapter.VKAdsKey, Bid: &adapters.BidDemandResponse{DemandID: adapter.VKAdsKey, Price: 1.0}},
+				{DemandID: adapter.VKAdsKey, Bid: &adapters.NormalizedBid{DemandID: adapter.VKAdsKey, Price: 1.0}},
 			},
 		},
 		{
@@ -156,15 +156,15 @@ func TestBidCache_ApplyBidCache(t *testing.T) {
 			},
 			want: []adapters.DemandResponse{
 				{DemandID: adapter.BigoAdsKey, Bid: nil, Error: errors.New("some error")},
-				{DemandID: adapter.MetaKey, Bid: &adapters.BidDemandResponse{DemandID: adapter.MetaKey, Price: 1.5}},
+				{DemandID: adapter.MetaKey, Bid: &adapters.NormalizedBid{DemandID: adapter.MetaKey, Price: 1.5}},
 			},
 		},
 		{
 			name: "has bids, has cache",
 			bids: []adapters.DemandResponse{
-				{DemandID: adapter.BidmachineKey, Bid: &adapters.BidDemandResponse{DemandID: adapter.BidmachineKey, Price: 1.0}},
-				{DemandID: adapter.VungleKey, Bid: &adapters.BidDemandResponse{DemandID: adapter.VungleKey, Price: 2.0}},
-				{DemandID: adapter.MetaKey, Bid: &adapters.BidDemandResponse{DemandID: adapter.MetaKey, Price: 2.5}},
+				{DemandID: adapter.BidmachineKey, Bid: &adapters.NormalizedBid{DemandID: adapter.BidmachineKey, Price: 1.0}},
+				{DemandID: adapter.VungleKey, Bid: &adapters.NormalizedBid{DemandID: adapter.VungleKey, Price: 2.0}},
+				{DemandID: adapter.MetaKey, Bid: &adapters.NormalizedBid{DemandID: adapter.MetaKey, Price: 2.5}},
 			},
 			cacheGet: bidding.Cache{
 				Bids: map[adapter.Key]bidding.CacheEntry{
@@ -195,14 +195,14 @@ func TestBidCache_ApplyBidCache(t *testing.T) {
 				},
 			},
 			want: []adapters.DemandResponse{
-				{DemandID: adapter.BidmachineKey, Bid: &adapters.BidDemandResponse{DemandID: adapter.BidmachineKey, Price: 1.0}},
-				{DemandID: adapter.VungleKey, Bid: &adapters.BidDemandResponse{DemandID: adapter.VungleKey, Price: 3.0}},
+				{DemandID: adapter.BidmachineKey, Bid: &adapters.NormalizedBid{DemandID: adapter.BidmachineKey, Price: 1.0}},
+				{DemandID: adapter.VungleKey, Bid: &adapters.NormalizedBid{DemandID: adapter.VungleKey, Price: 3.0}},
 			},
 		},
 		{
 			name: "has bids, has cheap cache",
 			bids: []adapters.DemandResponse{
-				{DemandID: adapter.VungleKey, Bid: &adapters.BidDemandResponse{DemandID: adapter.VungleKey, Price: 3.0}},
+				{DemandID: adapter.VungleKey, Bid: &adapters.NormalizedBid{DemandID: adapter.VungleKey, Price: 3.0}},
 			},
 			cacheGet: bidding.Cache{
 				Bids: map[adapter.Key]bidding.CacheEntry{
@@ -217,7 +217,7 @@ func TestBidCache_ApplyBidCache(t *testing.T) {
 				Bids: map[adapter.Key]bidding.CacheEntry{},
 			},
 			want: []adapters.DemandResponse{
-				{DemandID: adapter.VungleKey, Bid: &adapters.BidDemandResponse{DemandID: adapter.VungleKey, Price: 3.0}},
+				{DemandID: adapter.VungleKey, Bid: &adapters.NormalizedBid{DemandID: adapter.VungleKey, Price: 3.0}},
 			},
 		},
 	}
@@ -240,7 +240,7 @@ func TestBidCache_ApplyBidCache(t *testing.T) {
 
 			got := bidCache.ApplyBidCache(ctx, auctionRequest, aucResult)
 
-			if diff := cmp.Diff(tt.want, got, cmpopts.IgnoreFields(adapters.DemandResponse{}, "Error")); diff != "" {
+			if diff := cmp.Diff(tt.want, got, cmpopts.IgnoreFields(adapters.DemandResponse{}, "Error"), cmpopts.IgnoreFields(adapters.NormalizedBid{}, "Ext")); diff != "" {
 				t.Errorf("Create() mismatch (-want +got):\n%s", diff)
 			}
 

--- a/internal/bidding/builder.go
+++ b/internal/bidding/builder.go
@@ -228,7 +228,7 @@ func (b *Builder) processAdapter(
 		return
 	}
 
-	demandResponse, err = bidder.Adapter.ParseBids(demandResponse)
+	demandResponse, err = adapters.ParseDemandResponse(bidder.Adapter, demandResponse)
 	demandResponse.Error = err
 
 	bids <- *demandResponse

--- a/internal/sdkapi/grpc/test_helpers_test.go
+++ b/internal/sdkapi/grpc/test_helpers_test.go
@@ -279,7 +279,7 @@ func BuildDemandResponses(adUnits []auction.AdUnit) []adapters.DemandResponse {
 			DemandID: adapter.Key(adUnit.DemandID),
 		}
 		if adUnit.PriceFloor != nil {
-			response.Bid = &adapters.BidDemandResponse{
+			response.Bid = &adapters.NormalizedBid{
 				Price:    *adUnit.PriceFloor,
 				Payload:  "payload",
 				ID:       "123",

--- a/internal/sdkapi/v2/apihandlers/auction_handler_test.go
+++ b/internal/sdkapi/v2/apihandlers/auction_handler_test.go
@@ -168,7 +168,7 @@ func testHelperAuctionHandler() *apihandlers.AuctionHandler {
 					{
 						DemandID: "amazon",
 						SlotUUID: "uuid1",
-						Bid: &adapters.BidDemandResponse{
+						Bid: &adapters.NormalizedBid{
 							Price:    0.5,
 							ID:       "111",
 							ImpID:    "222",
@@ -177,7 +177,7 @@ func testHelperAuctionHandler() *apihandlers.AuctionHandler {
 					},
 					{
 						DemandID: "meta",
-						Bid: &adapters.BidDemandResponse{
+						Bid: &adapters.NormalizedBid{
 							Payload:  "payload",
 							Price:    0.6,
 							ID:       "123",
@@ -187,7 +187,7 @@ func testHelperAuctionHandler() *apihandlers.AuctionHandler {
 					},
 					{
 						DemandID: "mobilefuse",
-						Bid: &adapters.BidDemandResponse{
+						Bid: &adapters.NormalizedBid{
 							Price:      0.7,
 							ID:         "333",
 							ImpID:      "444",


### PR DESCRIPTION
## Summary
  - Centralize OpenRTB bid-response parsing at the bidding builder (`ParseDemandResponse`) so adapters no longer each implement nearly identical 
  `ParseBids`
  - Shrink the required bidder interface to `CreateRequest` + `ExecuteRequest`; optional `CustomBidParser` (zmaticoo) and `OpenRTBBidEnricher` 
  (yandex / mobilefuse / taurusx) for network-specific extraction
  - Rename `BidDemandResponse` → `NormalizedBid` and preserve raw OpenRTB `seatbid.bid.ext` on the DTO for post-parse enrichment (not forwarded on 
  SDK ad-unit extras)
  ## Details
  - Shared parse path handles HTTP status, JSON unmarshal, empty seatbid → no-bid, and standard field mapping
  - `ExecuteRequest` no longer parses bids (taurusx / zmaticoo)
  - Behavioral alignments: empty seatbid no longer panics; auth-style status handling unified; VKAds maps `adm` → `Payload`
  Blocks [BAC-19](https://linear.app/bidon/issue/BAC-19) (uSDK rendering config) so rendering can sit on `NormalizedBid.Ext` after parse.