### PR TITLE
BAC-20: Remove embedded static UI from bidon-admin

### DIFF
--- a/.github/workflows/prod-build.yml
+++ b/.github/workflows/prod-build.yml
@@ -38,7 +38,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        component: [bidon-admin, bidon-sdkapi, bidon-migrate, bidon-proxy, bidon-copilot]
+        component: [bidon-admin, bidon-sdkapi, bidon-migrate, bidon-proxy, bidon-copilot, bidon-ui]
     env:
       TARGET: ${{ matrix.component }}
     steps:

--- a/.gitignore
+++ b/.gitignore
@@ -21,10 +21,6 @@
 /**/.env
 /**/.envrc
 
-# Ignore UI static files, but keep the directory
-/cmd/bidon-admin/web/ui
-!/cmd/bidon-admin/web/ui/index.html
-
 .DS_Store
 
 public/system

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,15 +1,3 @@
-# Build UI
-FROM node:22-alpine AS frontend-deps
-
-WORKDIR /app
-
-COPY web/bidon_ui/package.json web/bidon_ui/yarn.lock ./
-RUN yarn install --frozen-lockfile
-
-ARG APP_ENV=production
-COPY web/bidon_ui .
-RUN VITE_APP_ENV=${APP_ENV} yarn generate
-
 FROM node:22-alpine AS bidon-ui-builder
 
 WORKDIR /app
@@ -42,7 +30,6 @@ COPY . .
 
 FROM base AS bidon-admin-builder
 
-COPY --from=frontend-deps /app/.output/public ./cmd/bidon-admin/web/ui
 RUN go build -o /bidon-admin ./cmd/bidon-admin
 
 FROM base AS bidon-sdkapi-builder

--- a/cmd/bidon-admin/main.go
+++ b/cmd/bidon-admin/main.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"io/fs"
 	"log"
 	"net/http"
 	"net/http/httputil"
@@ -25,7 +24,6 @@ import (
 	"github.com/labstack/echo/v4"
 	"github.com/labstack/echo/v4/middleware"
 
-	"github.com/bidon-io/bidon-backend/cmd/bidon-admin/web"
 	"github.com/bidon-io/bidon-backend/config"
 	"github.com/bidon-io/bidon-backend/internal/admin"
 	"github.com/bidon-io/bidon-backend/internal/admin/api"
@@ -116,25 +114,6 @@ func main() {
 
 	oapiWebServer := http.FileServer(http.FS(openapi.FS))
 	e.GET("/docs/*", echo.WrapHandler(http.StripPrefix("/docs/", oapiWebServer)))
-
-	uiFileSystem, _ := fs.Sub(web.FS, "ui")
-	uiWebServer := echo.WrapHandler(http.FileServer(http.FS(uiFileSystem)))
-	e.GET("/", uiWebServer)
-	e.GET("/*", uiWebServer, func(next echo.HandlerFunc) echo.HandlerFunc {
-		return func(c echo.Context) error {
-			file, err := uiFileSystem.Open(strings.TrimPrefix(c.Request().URL.Path, "/"))
-			if err != nil {
-				c.Request().URL.Path = "/"
-				return next(c)
-			}
-			err = file.Close()
-			if err != nil {
-				c.Logger().Warnf("Web server file.Close(): %v", err)
-			}
-
-			return next(c)
-		}
-	})
 
 	port := os.Getenv("PORT")
 	if port == "" {

--- a/cmd/bidon-admin/web/ui/index.html
+++ b/cmd/bidon-admin/web/ui/index.html
@@ -1,1 +1,0 @@
-This stub page would be replaced by the frontend statically built HTML during the Docker image build.

--- a/cmd/bidon-admin/web/web.go
+++ b/cmd/bidon-admin/web/web.go
@@ -1,6 +1,0 @@
-package web
-
-import "embed"
-
-//go:embed all:ui
-var FS embed.FS

--- a/internal/notification/handler_test.go
+++ b/internal/notification/handler_test.go
@@ -201,11 +201,14 @@ func TestHandler_HandleWin_ExternalNotificationsEnabled(t *testing.T) {
 	wg := &sync.WaitGroup{}
 	wg.Add(3) // Expect 3 notifications (1 win + 2 loss)
 
+	var mu sync.Mutex
 	var sentEvents []notification.Params
 	sender := &mocks.SenderMock{
 		SendEventFunc: func(_ context.Context, p notification.Params) {
 			defer wg.Done()
+			mu.Lock()
 			sentEvents = append(sentEvents, p)
+			mu.Unlock()
 		},
 	}
 
@@ -315,11 +318,14 @@ func TestHandler_HandleWin_NonRTBBid(t *testing.T) {
 	wg := &sync.WaitGroup{}
 	wg.Add(2) // Expect 2 notifications (1 win + 1 loss) for all bids regardless of incoming bid type
 
+	var mu sync.Mutex
 	var sentEvents []notification.Params
 	sender := &mocks.SenderMock{
 		SendEventFunc: func(_ context.Context, p notification.Params) {
 			defer wg.Done()
+			mu.Lock()
 			sentEvents = append(sentEvents, p)
+			mu.Unlock()
 		},
 	}
 
@@ -399,11 +405,14 @@ func TestHandler_HandleLoss_ExternalNotificationsEnabled(t *testing.T) {
 	wg := &sync.WaitGroup{}
 	wg.Add(2) // Expect 2 loss notifications
 
+	var mu sync.Mutex
 	var sentEvents []notification.Params
 	sender := &mocks.SenderMock{
 		SendEventFunc: func(_ context.Context, p notification.Params) {
 			defer wg.Done()
+			mu.Lock()
 			sentEvents = append(sentEvents, p)
+			mu.Unlock()
 
 			// Verify it's a loss notification
 			if p.NotificationType != "LURL" {
@@ -513,11 +522,14 @@ func TestHandler_HandleLoss_NonRTBBid(t *testing.T) {
 	wg := &sync.WaitGroup{}
 	wg.Add(2) // Expect 2 loss notifications for all bids regardless of incoming bid type
 
+	var mu sync.Mutex
 	var sentEvents []notification.Params
 	sender := &mocks.SenderMock{
 		SendEventFunc: func(_ context.Context, p notification.Params) {
 			defer wg.Done()
+			mu.Lock()
 			sentEvents = append(sentEvents, p)
+			mu.Unlock()
 
 			// Verify it's a loss notification
 			if p.NotificationType != "LURL" {

--- a/web/bidon_ui/CLAUDE.md
+++ b/web/bidon_ui/CLAUDE.md
@@ -263,9 +263,7 @@ node .output/server/index.mjs
 **Required environment variable:**
 - `NUXT_API_PROXY_TARGET` — URL of the Go `bidon-admin` backend (e.g. `http://bidon-admin:1323`). A warning is logged at startup if unset; falls back to `http://localhost:1323`.
 
-**Docker target:** `bidon-ui` in the root `Dockerfile` (uses `yarn build`, runs Node.js).
-
-**Note:** The root `Dockerfile` also contains a `bidon-admin-builder` stage that still embeds static files (via `yarn generate`) into the Go binary for deployments that do not use the separate `bidon-ui` container.
+**Docker target:** `bidon-ui` in the root `Dockerfile` (uses `yarn build`, runs Node.js). The `bidon-admin` image is API-only and does not embed UI assets.
 
 ## Testing
 

--- a/web/bidon_ui/README.md
+++ b/web/bidon_ui/README.md
@@ -1,4 +1,4 @@
-# Nuxt 3 Minimal Starter
+# Bidon Admin UI (Nuxt 3)
 
 Look at the [Nuxt 3 documentation](https://nuxt.com/docs/getting-started/introduction) to learn more.
 
@@ -12,34 +12,38 @@ yarn install
 
 ## Development Server
 
-Start the development server on `http://localhost:3000`
+Start the development server on `http://localhost:3000`:
 
 ```bash
 yarn dev
 ```
 
-## Local api
+The Nitro middleware (`server/middleware/proxy.ts`) proxies `/api/**` and `/auth/**` to the Go `bidon-admin` backend (`NUXT_API_PROXY_TARGET`, defaults to `http://localhost:1323`).
+
+With the full local stack (`docker compose -f docker-compose.dev.yml up`), the UI is available at `http://localhost:3010`.
+
+## Local API
 
 ```bash
-go run cmd/bidon-admin/main.go
+go run ./cmd/bidon-admin
 ```
 
-## Static build locally
+## Production build
 
-Frontend can be built statically, and that's how the production version works: frontend is built and then resulting files embedded into the backend, which serves them as-is. Node is not running, only the backend written in Go programming language, which also serves pre-built frontend HTML and JS and CSS files.
-
-Run `yarn generate` inside `./web/bidon_ui/`
-
-Copy static files to embed them into Go binary
+The UI runs as a standalone Nuxt/Node.js container (`bidon-ui`).
 
 ```bash
-cp -rf web/bidon_ui/.output/public/ cmd/bidon-admin/web/ui # assume you are in the root dir
+# Build (outputs Nitro server + static assets to .output/)
+yarn build
+
+# Run the production server
+NUXT_API_PROXY_TARGET=http://localhost:1323 node .output/server/index.mjs
+# → http://localhost:3000
 ```
 
-Run backend
+**Required environment variable:**
+- `NUXT_API_PROXY_TARGET` — URL of the Go `bidon-admin` backend (e.g. `http://bidon-admin:1323`)
 
-```bash
-go run cmd/bidon-admin/main.go
-```
+**Docker:** build the `bidon-ui` target in the root `Dockerfile` (`just build-ui` / `just ci-build-ui`).
 
 Check out the [deployment documentation](https://nuxt.com/docs/getting-started/deployment) for more information.


### PR DESCRIPTION
## Summary
- Make `bidon-admin` API-only by removing embedded static UI serving (`go:embed` package and `/` / `/*` routes)
- Drop the Dockerfile `frontend-deps` / `yarn generate` stage that copied assets into the Go binary
- Add `bidon-ui` to the prod build matrix and update docs for the standalone Nuxt container + proxy model