### PR TITLE
BAC-53: Backend telemetry M0/M1 discovery and store research

### DIFF
--- a/docs/telemetry-events-store.md
+++ b/docs/telemetry-events-store.md
@@ -1,0 +1,90 @@
+# Product events: Parquet on S3, SQL when needed, Iceberg when ready
+
+**Scope:** grain A only ([telemetry-requirements.md](./telemetry-requirements.md) §2.A). Grain B: [telemetry-traces-store.md](./telemetry-traces-store.md) (VictoriaTraces from day 1). Grain C: [telemetry-metrics-store.md](./telemetry-metrics-store.md) (VictoriaMetrics from day 1).  
+**Decision:** JSON → OSS Redpanda → **Parquet on object storage** → **DuckDB** (or Athena/Trino) when you query. **Iceberg** is the table format to adopt when an OSS writer + REST catalog are in place — not Redpanda Enterprise, not Connect’s licensed `iceberg` output. **ClickHouse** later reads the **same** lake.
+
+These are **phased**. Each phase keeps the wire format and `/v2/show` → Redpanda produce path.
+
+`/v2/show` produces events (and fires BURL). It does not query the lake.
+
+---
+
+## Argument
+
+Catalog SQL is delivery evidence (`sum(1 / sampling_rate)`, `GROUP BY dsp_id`, join `auction_id`), typically minutes to T+1 — normal in ad analytics. Real-time is BURL and later metrics/traces, not DuckDB.
+
+Redpanda is already paid for. Incremental store = sink that writes **Parquet**, plus an engine you start **when you have a question**.
+
+**Parquet** is the file encoding (never JSON-on-S3 for this catalog). **Iceberg** is a catalog + snapshots *over* those files so engines do not glob `dt=*`. **DuckDB** is the first engine (CLI/CI, `read_parquet` then Iceberg extension). CH is a query accelerator on the same files when load requires it.
+
+---
+
+## Phases
+
+### Phase 1 — Lake exists (M0 minimum)
+
+```
+bidon-sdkapi (JSON) → Redpanda telemetry-events
+                         → OSS consumer (Connect S3 parquet *or* a small writer)
+                         → s3://…/dt=YYYY-MM-DD/event_name=…/*.parquet
+                         → DuckDB: read_parquet('s3://…/dt=…/**')
+```
+
+- Envelope columns + `payload` JSON. Large parts (tens of MB). Dual-emit old topics unchanged.  
+- Redis `event_id` at ingest. Freshness = latest object vs topic lag.  
+- Saved SQL: funnel, DSP timeout, notice success, `GROUP BY event_name`.
+
+**Good enough** to size sampling and prove the catalog. Hive paths are a **temporary** layout.
+
+### Phase 2 — Iceberg table (OSS, no Enterprise)
+
+Do **not** wait for `redpanda.iceberg.mode` or Connect `output: iceberg:` (both license-gated).
+
+```
+same topic → PyIceberg (or Iceberg Java) consumer
+                → Parquet data files
+                → snapshot/manifest commit
+                → REST catalog (Polaris or iceberg-rest + MinIO/R2/S3)
+                → DuckDB Iceberg extension
+```
+
+`table.append(batch)` **is** writing Iceberg metadata. One writer, one table `bidon.telemetry_events`, partition on day(`event_ts`) + `event_name`.
+
+If Phase 1 already has hive Parquet: convert **before** file counts explode (rewrite into Iceberg once), or skip hive and start Phase 2 as soon as the catalog runs in Compose.
+
+### Phase 3 — Query load (optional engines)
+
+Same files/catalog. Add Athena (metered scan) or Trino only if DuckDB-over-S3 is the bottleneck. Not a new schema.
+
+### Phase 4 — ClickHouse (tripwire)
+
+When queries are daily/hourly, or DuckDB misses “minutes, not an afternoon,” or many concurrent SQL users: CH `Iceberg`/`S3` table on **that catalog**. No second event model. Do not buy CH Cloud to skip Phase 1–2.
+
+---
+
+## Drawbacks (accepted)
+
+- Lake lag (flush interval). Fine for PRD analytics; not for paging.  
+- Small files if you flush too often.  
+- No SQL `DELETE`; lifecycle/rewrite for retention and GDPR.  
+- DuckDB ≠ BI farm.  
+- Sink can stall while old Kafka looks healthy — alert freshness.  
+- Iceberg needs a **catalog** process; hive Parquet does not. That is why it is Phase 2, not a blocker for generating events.
+
+---
+
+## Generate / consume
+
+| Phase | Writer | What lands in the bucket |
+| --- | --- | --- |
+| 1 | Connect community S3 parquet, or any consumer | Hive-style Parquet |
+| 2+ | PyIceberg `append` (OSS) | Parquet **plus** Iceberg metadata + catalog pointer |
+
+JSON on the topic never changes.
+
+## M0 slice
+
+1. `telemetry-events` + Phase 1 sink (or Phase 2 if catalog is ready in the same sprint).  
+2. DuckDB SQL pack.  
+3. Freshness alert on the sink.  
+4. Written tripwire for Phase 4 (CH).

--- a/docs/telemetry-m0-m1-backend-spike.md
+++ b/docs/telemetry-m0-m1-backend-spike.md
@@ -1,0 +1,369 @@
+# Telemetry M0/M1 backend spike
+
+**Status:** Draft (backend audit + ticket list; no production instrumentation)  
+**Date:** 2026-08-21  
+**Source PRD:** [PRD_BidOn_Telemetry - v1.pdf](./PRD_BidOn_Telemetry%20-%20v1.pdf)  
+**Requirements:** [telemetry-requirements.md](./telemetry-requirements.md)  
+**Infrastructure spec:** [TRD_BidOn_Telemetry.md](./TRD_BidOn_Telemetry.md)  
+**Settled stores:** events (A) [telemetry-events-store.md](./telemetry-events-store.md) · traces (B) [telemetry-traces-store.md](./telemetry-traces-store.md) (VictoriaTraces) · metrics (C) [telemetry-metrics-store.md](./telemetry-metrics-store.md) (VictoriaMetrics)  
+**Historical (superseded):** [telemetry-storage-recommendation.md](./telemetry-storage-recommendation.md) (unified ClickHouse; do not implement)  
+**Linear initiative:** [Telemetry M0/M1 foundations](https://linear.app/bidon/initiative/telemetry-m0m1-foundations-validate-assumptions-and-size-the-build-2d2f5f28ed90) (read-only; this spike does not file or comment there)
+
+This document answers the backend-owned spike questions, inventories the event stream that already exists, maps it onto the PRD catalog, and lists M0/M1 backend tickets. SDK envelope/transport review stays with BID-46 / BID-47 / BID-54.
+
+## Verdict
+
+This is a **migration**, not a greenfield ingest.
+
+`bidon-sdkapi` already emits a production analytics stream to Redpanda (`ad-events`, `notification-events`). That stream is not the PRD M0 envelope: it has no `event_id` / `schema_version` / banded error model, it carries PII, and several PRD server events are missing or collapsed into a single `event_type`.
+
+Hard-cutting the current topics would break consumers that live outside this repo. Dual-emit old and new until those consumers migrate.
+
+Production instrumentation is **out of scope** for this spike. Implement after the mapping and TRD are accepted.
+
+## Scope
+
+**In**
+
+- Android-first, matching the PRD; this repo (`bidon-backend`) only
+- M0 envelope/ingest/config/OTel skeleton
+- M1 server events (auction, DSP fan-out, outbound notices) and the `/v2/show` impression/billing path
+
+**Out**
+
+- Any production event emission
+- M2 / M3 event implementation
+- Dashboards, alerting product, OM SDK
+- Creating or editing Linear issues, comments, or documents
+
+---
+
+## 1. Current pipeline
+
+```
+SDK  --POST /v2/{config,auction,stats,show,click,win,loss,reward}-->  bidon-sdkapi
+                                                                         |
+                                                                         | JSON AdEvent / NotificationEvent
+                                                                         v
+                                                              Redpanda: ad-events
+                                                                        notification-events
+                                                                         |
+                                                                         v
+                                                              consumers outside this repo
+
+bidon-sdkapi  --HTTP GET (3 retries)-->  DSP nurl / burl / lurl
+```
+
+Key packages:
+
+| Piece | Location |
+| --- | --- |
+| Event types + marshal | `internal/sdkapi/event/event.go` |
+| Kafka producer | `internal/sdkapi/event/engine/kafka.go`, `config/kafka.go` |
+| Auction + DSP events | `internal/auction/service.go` (`logEvents`, `prepareAuctionRequestEvent`, `prepareBiddingEvents`) |
+| Domain handlers | `internal/sdkapi/v2/router.go`, `internal/sdkapi/v2/apihandlers/*` |
+| Notices | `internal/notification/handler.go`, `internal/notification/event_sender.go` |
+| Country from IP | `internal/sdkapi/geocoder`, used in `BaseHandler.resolveRequest` via `c.RealIP()` |
+| OTel | Prometheus metrics + Echo/gRPC/GORM; traces exported to Sentry (`config/otel.go`) |
+
+Auth for SDK calls is **app key + bundle** lookup (`AppFetcher.FetchCached`), plus `X-Bidon-Version`. There is no dedicated telemetry credential.
+
+### 1.1 Endpoints that already produce events
+
+| Endpoint | Handler | `event_type`(s) | Side effects |
+| --- | --- | --- | --- |
+| `POST /v2/config` | `config_handler.go` | `config` | Adapter init payload |
+| `POST /v2/auction/{ad_type}` | `auction.Service.Run` | `auction_request`, per-DSP `bid_request`, successful `bid` | Bidding fan-out; Redis auction result for notices |
+| `POST /v2/stats/{ad_type}` | `stats_handler.go` | `stats_request`, `demand_request` (CPM), `client_bid` (RTB) | NURL/LURL if `external_win_notifications` is false |
+| `POST /v2/show/{ad_type}` | `show_handler.go` | `show` | BURL (billing) for bidding ads |
+| `POST /v2/click/{ad_type}` | `click_handler.go` | `click` | None |
+| `POST /v2/reward/{ad_type}` | `reward_handler.go` | `reward` | None |
+| `POST /v2/win/{ad_type}` | `win_handler.go` | `win` | NURL/LURL if `external_win_notifications` is true |
+| `POST /v2/loss/{ad_type}` | `loss_handler.go` | `loss` | LURL if `external_win_notifications` is true |
+
+There is **no** `/v2/telemetry` (or equivalent) batch ingest.
+
+### 1.2 Event inventory
+
+**Topic `ad-events` (`AdEvent`)**
+
+| `event_type` | When | Notable fields beyond the common envelope |
+| --- | --- | --- |
+| `config` | Config fetch | Status `SUCCESS` |
+| `auction_request` | After auction build (also on error, via `defer`) | `status` SUCCESS/ERROR, `error`, `price_floor` |
+| `bid_request` | Per DSP after the HTTP call returns | `demand_id`, HTTP `status` as string, `ecpm`, `raw_request`, `raw_response`, `error`, `timing_map.bid` + `timing_map.token` |
+| `bid` | Per DSP when `DemandResponse.IsBid()` | `ecpm` = bid price, `timing_map.bid` |
+| `stats_request` | Client reports auction outcome | Winner demand/price, `timing_map.auction` |
+| `demand_request` | Per CPM ad unit in stats | Unit `status`, fill timings, `error` |
+| `client_bid` | Per RTB ad unit in stats | Fill + token timings |
+| `show` | Impression callback | Demand, ad unit, price |
+| `click` | Click callback | Same bid identity fields |
+| `reward` | Reward callback | Same |
+| `win` | External win notification path | Same |
+| `loss` | External loss path | Plus `external_winner_demand_id` / `external_winner_ecpm` |
+
+Common `AdEvent` fields (always populated from `BaseRequest` + geo): timestamp, device (manufacturer, model, os, os_version, connection_type, device_type, user_agent), session (id, uptime, RAM, battery, CPU, storage, memory-warning timestamps), app (bundle, versions, framework, plugin), identifiers (`idfa`, `idg`, `idfv`, `app_set_id`), regulations (COPPA, GDPR), geo (`country_code`, `city`, `ip`, `country_id`), segment, `ext`, `mediation_mode`, `mediator`.
+
+Missing versus the PRD envelope: `event_id`, `event_name`, `schema_version`, `host`, `auction_owner`, `integration_mode`, `sampling_rate`, `publisher_id`, banded `error_domain` / `error_code`, `demand_type`, OM fields.
+
+**Topic `notification-events` (`NotificationEvent`)**
+
+| `event_type` | OpenRTB meaning | When |
+| --- | --- | --- |
+| `NURL` | Win notice | Stats SUCCESS (internal path) or `/win` (external path) |
+| `LURL` | Loss notice | Below floor; stats FAIL / AUCTION_CANCELLED; `/loss`; losers on `/win` |
+| `BURL` | Billing notice | `/v2/show` for a bidding impression |
+| `TimeoutURL` | Timeout | DSP deadline exceeded and adapter supplied a timeout URL (Meta today) |
+
+`NotificationEvent` fields: timestamp, event_type, bundle, ad_type, demand_id, auction_id, imp_id, loss_reason, ecpm, first_price, second_price, url, template_url, error. No device, no geo, no `http_status`, no `retry_count`, no `success`, no `latency_ms`.
+
+Retries: exponential backoff, max 3, in `EventSender.SendEvent`. Failure is a log line plus `Error` on the event; there is no `notice_delivery_failed` event.
+
+### 1.3 PII on the current stream
+
+The PRD forbids PII on telemetry. Today's `AdEvent` includes:
+
+| Field | Why it is PII / sensitive |
+| --- | --- |
+| `idfa`, `idfv`, `idg`, `app_set_id` | Advertising / device identifiers |
+| `ip` | Client IP from geocoder |
+| `city` | Finer than country |
+| `user_agent` | Often treated as personal in combination with IP |
+| `raw_request`, `raw_response` on `bid_request` | Full DSP payloads; can include user/device data Bidon forwarded |
+| Session RAM / battery / storage | Device fingerprinting surface |
+
+`country_code` / `country_id` are server-derived from MaxMind and are allowed (PRD: country is server-side, never from the client).
+
+`NotificationEvent` is thinner but `url` is the fully expanded notice URL (macros substituted), which can carry auction/user identifiers the DSP embedded.
+
+### 1.4 How `mediation_mode` / `mediator` are set
+
+Not enums. They are optional strings copied from request `ext`:
+
+```90:105:internal/sdkapi/schema/base_request.go
+func (r *BaseRequest) GetMediationMode() string {
+	ext := r.GetExtData()
+	if mode, ok := ext["mediation_mode"].(string); ok {
+		return mode
+	}
+	return ""
+}
+```
+
+Empty when the SDK omits them. The PRD `host` / `auction_owner` / `integration_mode` model is not implemented.
+
+---
+
+## 2. Spike answers (backend)
+
+Numbering matches the Linear initiative.
+
+### Q1. Does Bidon emit telemetry today?
+
+**Yes, on the server.** The SDK already posts domain events (`/v2/stats`, `/v2/show`, …) and the server additionally emits auction/DSP/notice events to Kafka. This is **not** the PRD schema.
+
+**Cutover:** dual-emit. Old topics stay until the unnamed downstream consumer of `ad-events` / `notification-events` is migrated. A hard cutover is unsafe.
+
+Who consumes those topics is **not in this repo** (README mentions a `bidon-ad-events` topic historically; compose uses `ad-events`). Owner must be named before monthly cost can close. See TRD open items.
+
+### Q4. Direct-mode auction mechanics
+
+- **Rounds:** one server bidding round. `bidding.Builder.HoldAuction` fans out to adapters in parallel (`internal/bidding/builder.go`). `AuctionResult.RoundNumber` is hardcoded to `0`.
+- **Price floor:** per-request. Mixed from SDK `auction_pricefloor`, auction-config floor, cached ads, and (custom-adapter) `previous_auction_price` (`auction.priceFloor`).
+- **Waterfall:** server returns ranked `ad_units` + `no_bids`. The SDK walks the waterfall. Re-sort after a failed load is client-side. Server sees the outcome later on `/v2/stats`.
+
+### Q5. Can the waterfall expose `waterfall_position` and `attempts_made`?
+
+Not as first-class server fields today.
+
+`/v2/stats` already receives ordered `ad_units[]` with per-unit `status`, `fill_start_ts` / `fill_finish_ts`, and `error_message` (`internal/sdkapi/schema/stats_request.go`). If the SDK preserves **attempt order**, ingest can derive:
+
+- `waterfall_position` = index in `ad_units` (1-based)
+- `attempts_made` = count of units with a terminal status, or `len(ad_units)`
+
+If the array is not attempt-ordered (e.g. ranked or winner-first), that is an **SDK stats-payload** change, not a server waterfall refactor. M1 headline metrics (fill rate, time to fill, per-source load rate) are therefore **not blocked on a backend restructure**; they are blocked on the SDK preserving order (or sending the two fields explicitly).
+
+Listed separately in the ticket list because that confirmation is the largest remaining uncertainty on the stats path.
+
+### Q9. Can `ad_impression` ride the ad-serving channel?
+
+**Yes. It already does.**
+
+`POST /v2/show/{ad_type}` is the impression callback. `notification.Handler.HandleShow` fires BURL (billing) from that request for bidding ads. The Kafka `show` event is best-effort *after* the HTTP handler returns.
+
+Billing is coupled to `/show` succeeding, not to Kafka. The PRD exception is: keep billing on `/show` (or a successor ad-path call). Do **not** move it onto the SDK batch queue.
+
+Warehouse `ad_impression` should be emitted from `/show` onto the new topic, with `event_id` dedupe if the SDK also sends `ad_impression` for reconciliation. Server copy from `/show` is source of truth for `billing_notice_sent`.
+
+Gap: `EventSender` does not record HTTP status, latency, or retry count, so `billing_notice_sent` cannot yet satisfy the PRD field list.
+
+### Q10. Reusable network client for telemetry ingest?
+
+The bidding HTTP client (`otelhttp` transport, 4s timeout in `cmd/bidon-sdkapi/main.go`) is **outbound to DSPs**, not an ingest server.
+
+- Server-emitted events can keep using `event.Logger` → Kafka.
+- Client batch ingest is **new work** (endpoint, auth, dedupe, geocode). SDK retry/cert handling is SDK M0 (BID-47).
+
+### Auction ID (PRD Note 1 vs code)
+
+PRD: in M1/M2 the server mints `auction_id` and returns it in the auction response.
+
+Code: `auction_id` is **required on the request** (`schema.AdObject`). `buildResponse` echoes `req.AdObject.AuctionID`. Server does not mint it.
+
+Changing this is a coordinated SDK + OpenAPI change, not a silent backend fix. Deferred with owner: SDK + backend jointly. Until then, correlation uses the SDK-supplied id.
+
+### OTel today
+
+- Metrics: Echo Prometheus middleware, Redis cache observers, gRPC interceptors, `otelhttp` on the bidding client.
+- Traces: `ConfigureOTel()` installs a Sentry span processor (`config/otel.go`). There is **no** auction-scoped trace with a child span per DSP.
+- Sentry traces are not a funnel store and not the grain-B backend. Auction trees **will** export to **VictoriaTraces**; Sentry stays exceptions only.
+
+### Remote config today
+
+`POST /v2/config` returns `init.tmax`, adapter init configs, segment, `bidding.token_timeout_ms`. No sampling rates, no telemetry kill switch (BID-47).
+
+---
+
+## 3. PRD server events vs current names
+
+| PRD event | Closest current event | Gap |
+| --- | --- | --- |
+| `auction_request_received` | `auction_request` | No `participant_count`, no DSP list; logged after build, not at request accept |
+| `dsp_request_sent` | *(none)* | `bid_request` is post-hoc after the HTTP call. `StartTS` on `DemandResponse` is the **auction** start (`params.StartTS`), not send time |
+| `dsp_response_received` | `bid_request` + `bid` | `Status` is an HTTP code string, not `bid/nobid/timeout/http_error/malformed`. No `nbr`, `creative_id`, `crtype`, `supports_omid`. `ParseBids` errors fold into `Error` |
+| `dsp_response_rejected` | part of `bid_request` / immediate LURL | Below-floor bids send LURL in `HandleBiddingRound` but are not a distinct telemetry event. No `reason` enum (`below_floor/schema_invalid/missing_adm_fields/blocked_category/expired`) |
+| `auction_completed` | *(none on server)* | Closest is client `stats_request`. Server could emit at bidding-round end (winner among DSP bids + network line items), which is **not** the same as fill |
+| `win_notice_sent` | `NURL` | Missing success, http_status, retry_count, latency_ms |
+| `billing_notice_sent` | `BURL` | Same |
+| `loss_notice_sent` | `LURL` | Same; `TimeoutURL` is an extra current type |
+| `notice_delivery_failed` | `Error` field on NotificationEvent | Not a distinct event; retry count not recorded |
+
+Client-side PRD events (`sdk_init_*`, `adapter_token_*`, `ad_load_*`, `ad_impression` from the renderer, waterfall attempt events) are **not** emitted by this repo. They will arrive via the new ingest (or continue to be implied by domain endpoints during dual-emission).
+
+M1 funnel metrics that need **both** sides:
+
+| Metric | Server contribution | Still needs SDK |
+| --- | --- | --- |
+| Bid rate / DSP timeout rate | `dsp_response_received.outcome` | No |
+| Notice delivery rate | upgraded notice events | No |
+| Fill rate, time to fill, per-source load rate | `/v2/stats` order/fields | `waterfall_position` / `attempts_made` (or guaranteed attempt order) |
+| Render rate | `/v2/show` as `ad_impression` | Renderer-side `ad_filled` if `/show` is not the fill signal |
+
+---
+
+## 4. Dual-emission rules
+
+1. Keep writing `ad-events` and `notification-events` unchanged until the downstream owner signs off.
+2. New PRD events go to a new topic (`telemetry-events`; see TRD).
+3. Do not widen `AdEvent` in place to look like the M0 envelope. That mixes PII policy and schema versioning.
+4. `/v2/show` remains the billing trigger. New `ad_impression` / `billing_notice_sent` are additional writes from that handler, not a replacement of BURL.
+5. If the SDK later posts `ad_impression` to ingest as well, dedupe on `event_id` (or a derived key `show:{auction_id}:{demand_id}` during transition).
+6. Cutover of the old topics is a separate ticket after warehouse queries are rewritten. Not part of M1.
+
+---
+
+## 5. Proposed backend architecture (not implemented)
+
+Three grains, three stores. Details in the store docs; this is the wiring.
+
+```
+SDK domain routes + POST /v2/telemetry
+        │
+        v
+  bidon-sdkapi ── JSON envelope ──► Redpanda telemetry-events ──► Parquet sink ──► S3 ──► DuckDB
+        │                              │                              (Iceberg later; CH later on same files)
+        │                              └── dual-emit unchanged ──► ad-events / notification-events
+        │
+        ├── GET /metrics ── scrape ──► VictoriaMetrics ◄── vmalert ──► Alertmanager
+        │
+        └── OTLP ──► otelcol-contrib ──► VictoriaTraces          (GET trace_id)
+                         └── spanmetrics ──► VictoriaMetrics     (p95 / paging; no auction_id labels)
+
+/v2/show: BURL + ad_impression produce; does not query any of the above.
+```
+
+| Grain | Job | Store |
+| --- | --- | --- |
+| A | Catalog SQL (`sampling_rate`, join `auction_id`) | Redpanda `telemetry-events` → Parquet/Iceberg → DuckDB |
+| B | Per-auction span tree | OTLP → **VictoriaTraces** |
+| C | “Page if X is bad for N minutes” | **VictoriaMetrics** (scrape `/metrics` + spanmetrics) |
+
+Keep Redpanda as the ingest bus. Add `telemetry-events` with the M0 envelope.
+
+Two producers, one schema:
+
+1. **Server-native** — `auction.Service` and `notification.EventSender`, fire-and-forget (same pattern as `EventLogger.Log` today). Must not delay the auction HTTP response.
+2. **Client batch ingest** — new `POST /v2/telemetry`. Auth = existing app key + bundle. Server fills `country` from MaxMind. Dedupe on `event_id`.
+
+`/v2/config` grows a `telemetry` object: per-event sampling rates, publisher kill switch. Per-auction kill switch on the auction response can wait; not required for M0.
+
+OTel: span in `auction.Service.Run`, child span per DSP in `bidding.Builder`, child spans on notice sends. Export via **otelcol-contrib → VictoriaTraces**. Turn Sentry span export **off** the auction path; keep Sentry for exceptions. Spanmetrics from the collector into **VictoriaMetrics** — do not put `auction_id` on series.
+
+Infra not in the Go ticket list: Compose/Coolify for VM, VT, otelcol, Parquet sink, object-storage bucket. Owners still unnamed.
+
+Details: [TRD_BidOn_Telemetry.md](./TRD_BidOn_Telemetry.md).
+
+---
+
+## 6. Open items this repo cannot close
+
+| Item | Why | Owner |
+| --- | --- | --- |
+| Who consumes `ad-events` / `notification-events` today | No consumer in this repo | Data / infra (unnamed) |
+| Object-storage bucket, Parquet sink, VM, VT, otelcol | Stores are **chosen**; who runs them and monthly $ (volume unmeasured) are not | Infra (unnamed) |
+| Server-minted `auction_id` | Breaking vs current required request field | SDK + backend jointly |
+| Stats array = attempt order? | Determines whether Q5 is ingest-only | SDK |
+| Impression definition (`ad_impression` vs OM viewable) | PRD assigns this to the OM spike | OM spike |
+| AppLovin timeout / configured CPM / signal timeout (Q14–16) | MAX adapter, not this repo | Demand / SDK |
+| BID-46 envelope sign-off | Schema freeze before backend types | Tiziano, Jonathan (per BID-46) |
+| Ad-path latency gate (PRD target N/A) | Product decision | Initiative owner |
+
+---
+
+## 7. M0 + M1 backend tickets
+
+Days are **TBC**. Tickets assume BID-46 envelope is signed off before M0 types land. They do **not** include Grafana dashboards, SDK work, Compose/Coolify for VM/VT/otelcol/sink, or Linear filing.
+
+Waterfall/stats work is listed separately (highest remaining uncertainty on the client-reported path). DSP fan-out work is the highest uncertainty on the server-native path.
+
+### M0 — foundation
+
+| ID | Ticket | Days | Notes |
+| --- | --- | --- | --- |
+| BE-M0-1 | Shared envelope types + `schema_version` in a new `internal/telemetry` package (do not extend `AdEvent`) | TBC | Blocked on BID-46. Include `event_id`, host/auction_owner/integration_mode, sampling_rate |
+| BE-M0-2 | `telemetry-events` Kafka topic + logger engine next to `internal/sdkapi/event` | TBC | Env var `KAFKA_TELEMETRY_EVENTS_TOPIC`; compose/dev/staging wiring |
+| BE-M0-3 | `POST /v2/telemetry` ingest: batch parse, app-key auth, schema validation, `event_id` dedupe, MaxMind `country`, reject 4xx vs drop 5xx policy | TBC | See TRD ingest. Never sample errors |
+| BE-M0-4 | `/v2/config` `telemetry` block: per-event sampling rates, publisher kill switch | TBC | Storage: app settings or dedicated config table. Per-auction kill switch **not** in this ticket |
+| BE-M0-5 | Privacy enforcement on the new stream: no IP/IFA/IDFV/city; COPPA reduced field set; scrub `error_message`; do not copy `raw_request`/`raw_response` | TBC | Old topics stay as they are during dual-emission |
+| BE-M0-6 | OTel auction trace skeleton: span in `Service.Run`, child per DSP, exemplar-friendly | TBC | Export **otelcol → VictoriaTraces**. Sentry exceptions only. Spanmetrics → VictoriaMetrics (no `auction_id` labels). No new business events in this ticket |
+
+### M1 — direct mode, server events
+
+| ID | Ticket | Days | Notes |
+| --- | --- | --- | --- |
+| BE-M1-1 | DSP fan-out events: `dsp_request_sent` at send time; `dsp_response_received` with outcome enum; `dsp_response_rejected` with reason | TBC | Highest server uncertainty: map HTTP/timeout/parse/below-floor onto PRD outcomes; capture `nbr`/`creative_id`/`crtype`/`supports_omid` where adapters already parse them (many do not) |
+| BE-M1-2 | `auction_request_received` at request accept + `auction_completed` at bidding-round end | TBC | Distinct from fill. Include winner_demand_source, clearing_price, participant_count, total_latency_ms |
+| BE-M1-3 | Notice events: success, http_status, retry_count, latency_ms on win/billing/loss; add `notice_delivery_failed` | TBC | Requires `EventSender` to observe the HTTP response instead of swallowing it |
+| BE-M1-4 | `/v2/show` emits `ad_impression` + `billing_notice_sent` onto `telemetry-events`; keep BURL behaviour | TBC | Delivery guarantee = the `/show` HTTP call. Dedupe key documented in TRD |
+| BE-M1-5 | Dual-write: existing `AdEvent`/`NotificationEvent` unchanged alongside new events | TBC | Feature-flag off-switch for the new topic only |
+| BE-M1-6 | **Waterfall / fill (listed separately):** derive `waterfall_position` / `attempts_made` from `/v2/stats` **or** accept explicit SDK fields; emit data needed for fill rate / time to fill / per-source load rate | TBC | Confirm with SDK before scheduling (stats order vs payload change). Not a server waterfall rewrite |
+
+### Suggested sequence
+
+1. BE-M0-1, BE-M0-2 (schema + bus)
+2. BE-M0-5 then BE-M0-3 (privacy before ingest goes live)
+3. BE-M0-4 (config must ship before SDK sampling is useful)
+4. BE-M0-6 (can parallelise with 3)
+5. BE-M1-5 flag plumbing, then BE-M1-1 and BE-M1-2 (instrument auction path once)
+6. BE-M1-3, BE-M1-4 (notices + impression)
+7. BE-M1-6 only after SDK confirms stats ordering
+
+Do not emit M1 events before M0 ingest/schema exist, or dual-emission will invent a third schema.
+
+### Explicitly not ticketed here
+
+- M2 `adapter_load_budget_exceeded` / `configured_cpm`
+- M3 bid-request handling / inbound MAX notices
+- Compose/Coolify: VictoriaMetrics, VictoriaTraces, otelcol-contrib, Parquet sink, bucket
+- Iceberg catalog, ClickHouse-on-the-lake (events Phase 4), Grafana dashboards, PagerDuty
+- Filing these rows in Linear

--- a/docs/telemetry-metrics-store.md
+++ b/docs/telemetry-metrics-store.md
@@ -1,0 +1,130 @@
+# Operational metrics: VictoriaMetrics from day 1
+
+**Scope:** grain C only ([telemetry-requirements.md](./telemetry-requirements.md) §2.C). Grain A: [telemetry-events-store.md](./telemetry-events-store.md). Grain B: [telemetry-traces-store.md](./telemetry-traces-store.md) (VictoriaTraces from day 1). Spike architecture: [telemetry-m0-m1-backend-spike.md](./telemetry-m0-m1-backend-spike.md) §5.
+
+**Decision:** scrape existing `GET /metrics` (and later the OTel Prometheus exporter) into **single-node VictoriaMetrics**. **vmalert** evaluates rules; **Alertmanager** pages. Grafana uses the Prometheus datasource pointed at VM. **`vmbackup` to S3** when local retention is not enough. **VM cluster** only if scrape volume hurts.
+
+These are **phased**. Each phase keeps the produce path: in-process Prometheus *client* on `/metrics`. We are not running a Prometheus *server*.
+
+`/v2/show` does not query VM. If VM is down, ads still serve; you just do not page (G1/G2).
+
+---
+
+## Argument
+
+Alerts need a process that answers PromQL every minute. Events can sit unread on S3; **this grain cannot**. The lake-like part is cheap local retention (VM compression) plus optional cold copies on object storage — not a metered SaaS TSDB, not Parquet+DuckDB `rate()`.
+
+The repo already **exposes** Prometheus text. VM is Prometheus-compatible for scrape, Grafana, and (via vmalert) alerting rules. MetricsQL is a PromQL superset; typical dashboards work. `rate`/`increase` are intentionally slightly different from Prometheus — acceptable for new rules written against VM.
+
+Do not put `auction_id` (or any high-cardinality id) on a series. Per-auction latency lives in **traces (B)** or **events (A)**.
+
+---
+
+## Same model as the event lake
+
+| Event lake (A) | Metrics (C) |
+| --- | --- |
+| Produce JSON, do not await the warehouse | Increment counters in-process; do not await VM |
+| Redpanda is the durable log | VM local storage is the durable log for the hot window |
+| Parquet on S3 is the cheap retain | **`vmbackup` (later cluster VM)** on the same bucket family, `metrics/` prefix |
+| DuckDB when a human runs SQL | **MetricsQL** when vmalert or Grafana runs a range query |
+| Iceberg when writers/engines need a catalog | VM cluster when one node is not enough |
+| ClickHouse later as a hot accelerator | Do not add CH *only* for metrics |
+
+---
+
+## How series are born (produce)
+
+The app never blocks on VM.
+
+| Source | What it is | Labels (keep tiny) |
+| --- | --- | --- |
+| Existing `/metrics` | Process, HTTP, Go runtime | `job`, `instance`, maybe `path` **not** auction |
+| New counters on `/v2/show` | Impression handler success/fail, BURL enqueue fail | `job`, `result` |
+| OTel **spanmetrics** (from grain B) | `dsp_request_duration`, timeout count | `dsp`, `operation` — **never** `trace_id` / `auction_id` |
+| Collector scrape fail | Pipeline health | `job` |
+
+Do **not** page off the event lake until sink freshness is inside the alert `for:` window. Until that SLO exists, use scrape.
+
+---
+
+## Phases
+
+### Phase 1 — single-node VM (M0, day 1)
+
+```
+bidon-sdkapi GET /metrics  →  VictoriaMetrics (single, scrape)
+otelcol Prometheus exporter ↗
+                              →  vmalert  →  Alertmanager
+                              →  Grafana (Prometheus datasource → VM)
+```
+
+- Compose/Coolify sidecar. Retention **30–90d** is fine on one disk at low cardinality; no need to start at 15d.
+- Scrape config can live on VM itself for a handful of targets. Split out **vmagent** only if scrape fan-out grows.
+- Rules: Prometheus-style YAML in **vmalert**. Alertmanager for routing.
+- Query language: MetricsQL. Write new alerts against VM; do not assume Prometheus `rate()` extrapolation.
+
+**Good enough** to prove C: “page if DSP timeout rate is bad for N minutes.”
+
+### Phase 2 — cold copy on object storage (when local disk is not enough)
+
+`vmbackup` to `s3://…/metrics/` (same bucket family as events, different prefix). This is backup/restore and capacity relief, not a live PromQL-on-S3 lake. Alerts still hit **Phase 1**.
+
+Not Thanos: VM is not Prometheus TSDB blocks. Not Mimir. Not Iceberg of Prom samples.
+
+### Phase 3 — VM cluster (only if scrape volume hurts)
+
+vminsert / vmselect / vmstorage. Skip until one node is the problem. Do not stand up ClickHouse *only* for metrics.
+
+---
+
+## What we are not doing
+
+| Skip | Why |
+| --- | --- |
+| Prometheus *server* | VM from day 1; `/metrics` client stays |
+| Thanos sidecar | Wrong on-disk format |
+| Grafana Cloud / Datadog / Chronosphere | Metered SaaS |
+| Iceberg tables of Prom samples | Wrong query language |
+| Kafka topic of every scrape sample | Redpanda is the **event** log. VM has its own WAL |
+| High-cardinality labels | `auction_id`, `creative_id`, raw endpoint URLs |
+| Lake-derived alerts before sink SLO | Freshness unknown; pages would lie |
+
+---
+
+## Relationship to A and B
+
+- **A (events):** historical fill rate — SQL on Parquet. Not paging.
+- **B (traces):** p95 / timeout on **this auction** — span store. Spanmetrics **rolls B up into C** without putting ids on series.
+- **C (this doc):** “is it bad *right now* for this DSP / this job.”
+
+Three grains can share **object storage** (prefixes) and **one Grafana**. They do not share one table format.
+
+---
+
+## Compatibility (so we do not get surprised)
+
+VM is **Prometheus-compatible**, not Prometheus:
+
+- `/metrics` scrape, Grafana Prometheus datasource, Alertmanager: yes.
+- Recording/alerting rules: **vmalert**, not in-process Prometheus.
+- MetricsQL vs PromQL: `rate`/`increase` differ on purpose (no extrapolation; include sample before the window).
+- Migration off Prometheus disk: N/A — we never run a Prometheus server.
+
+---
+
+## Decision
+
+| Item | Choice |
+| --- | --- |
+| Hot store (alerts) | Single-node **VictoriaMetrics**, scrape `/metrics` + OTel Prometheus exporter |
+| Rules / paging | **vmalert** + **Alertmanager** |
+| Dashboards | Grafana → Prometheus datasource → VM |
+| Cold store (optional) | **`vmbackup`** to S3 `metrics/` prefix |
+| Scale-up | VM cluster, not CH-for-metrics |
+| Not Iceberg | Metrics are MetricsQL, not DuckDB |
+| Not the event topic | Do not dual-write samples to `telemetry-events` |
+| Labels | Low cardinality only; no `auction_id` |
+| Lake alerts | Only after sink freshness ≤ alert `for` window |
+
+Owners still needed: who runs the VM instance, vmalert rules, alert routing, and (later) the metrics prefix on the bucket.

--- a/docs/telemetry-requirements.md
+++ b/docs/telemetry-requirements.md
@@ -1,0 +1,175 @@
+# Telemetry: requirements (clean slate)
+
+**Status:** Draft — requirements only. Settled stores: grain A → [telemetry-events-store.md](./telemetry-events-store.md); grain B → [telemetry-traces-store.md](./telemetry-traces-store.md) (VictoriaTraces from day 1); grain C → [telemetry-metrics-store.md](./telemetry-metrics-store.md) (VictoriaMetrics from day 1).  
+**Date:** 2026-08-21  
+**PRD:** [PRD_BidOn_Telemetry v1](./PRD_BidOn_Telemetry%20-%20v1.pdf)  
+**TRD:** [TRD_BidOn_Telemetry.md](./TRD_BidOn_Telemetry.md)  
+**Code audit:** [telemetry-m0-m1-backend-spike.md](./telemetry-m0-m1-backend-spike.md)
+
+Vendor notes from earlier discussion are *not* requirements. This document is what a store (or stores) must satisfy.
+
+**Settled (choice):** grain A = Parquet/Iceberg lake; grain B = VictoriaTraces; grain C = VictoriaMetrics. Three stores because alerts cannot wait on lake lag, and a trace is a point-get, not funnel SQL. Unified ClickHouse is rejected ([telemetry-storage-recommendation.md](./telemetry-storage-recommendation.md) is history only).
+
+---
+
+## 1. Why this exists (jobs)
+
+The PRD is delivery evidence, not a dashboard product.
+
+| # | Job | Who | If we fail |
+| --- | --- | --- | --- |
+| J1 | Reconstruct an ad request’s path from init/load → terminal outcome | Eng, support | Cannot tell Bidon vs publisher vs DSP |
+| J2 | Attribute a failure to a domain + stable code (foreign code preserved) | Eng, partners | Every escalation is a reproduction |
+| J3 | Quote fill, time-to-fill, render rate, per-source load, DSP timeout | Pub support, BD | No proving-ground numbers for MAX |
+| J4 | Reconcile Bidon impressions vs mediator / DSP billing | Cert, finance | Accept AppLovin’s numbers |
+| J5 | Show per-DSP loss and render (acquisition + DSP ops) | BD, solutions | No commercial evidence |
+| J6 | See where the latency budget went (token / auction / DSP / notices) | Server eng | Timeouts are vibes |
+| J7 | Do all of the above without slowing the ad path | Everyone | Telemetry is net-negative |
+
+M0/M1 only: Android-first, direct mode (+ server pieces reused in later modes). M2/M3 events, OM, and a reporting UI are out of this slice.
+
+---
+
+## 2. Three kinds of data (do not collapse them in the spec)
+
+They may share *infrastructure*. They must not share *grain*. Mixing grains is how Sentry and `/metrics` failed as the answer.
+
+### A. Product events (the catalog)
+
+One row per thing that happened, PRD envelope (`event_id`, `event_name`, `schema_version`, `auction_id`, `session_id`, `sampling_rate`, …).
+
+Server must produce at least (M1):  
+`auction_request_received`, `dsp_request_sent`, `dsp_response_received`, `dsp_response_rejected`, `auction_completed`, `win|billing|loss_notice_sent`, `notice_delivery_failed`.  
+`ad_impression` / billing are **derived from `/v2/show`**, not from the SDK batch queue.
+
+Client events arrive via a new ingest (`/v2/telemetry`) and/or existing domain routes during dual-emission.
+
+**Queries (must work):**
+
+- Funnel: count `ad_request_started` → `ad_filled` → `ad_impression` → `billing_notice_sent`, **corrected by** `1 / sampling_rate`.
+- `GROUP BY dsp_id` / `demand_source` / `error_code`.
+- Join client + server on `auction_id` (today SDK-minted).
+- Never-sampled classes still present: errors, impressions, notices.
+
+**This is the warehouse.** If a system cannot do those joins, it is not the event store.
+
+### B. Traces (per-auction tree)
+
+One trace per auction; child span per DSP call; notice spans. Attributes include `auction_id` so events and traces join.
+
+**Queries (must work):**
+
+- Fetch the tree for auction/trace X (point lookup).
+- Quantiles of span duration by `demand_id` over a window (baselines). Head-sample rate **known and recorded** if traces are used for p95; otherwise p95 comes from C, not from “only slow traces we kept.”
+
+**UI is not an M0 requirement.** Storage is. Sentry is not this store (not actionable for reports).
+
+**This is not the funnel.** You do not define fill rate from spans.
+
+### C. Operational signals (alerts)
+
+Low-cardinality time series: ingest 5xx, Kafka produce fail, DSP timeout *rate*, notice failure *rate*, process health.
+
+**Queries (must work):** “page if X is bad for N minutes.” Grain is *not* `auction_id`.
+
+Today `GET /metrics` **exposes** Prometheus text. Nothing in this repo **stores** it. A scrape endpoint is not a requirement satisfied.
+
+---
+
+## 3. Guarantees (non-negotiable)
+
+| ID | Requirement |
+| --- | --- |
+| G1 | Telemetry must not delay or fail an ad request (enqueue, do not await), except G2. |
+| G2 | Impression + BURL stay on `POST /v2/show`. Warehouse row may lag; billing must not. |
+| G3 | New stream: no PII (no IP/IFA/IDFV). `country` from MaxMind. COPPA reduced set. |
+| G4 | Dual-emit existing `ad-events` / `notification-events` until that consumer is named and migrated. New catalog is a **new** stream. |
+| G5 | Dedupe on `event_id` at ingest (Redis 72h is the TRD default). |
+| G6 | Errors never sampled. Sampling rate on the event; server does not re-sample. |
+| G7 | Kill switch via `/v2/config` (publisher). |
+| G8 | Schema versioned; additive within a major. |
+| G9 | Collector/pipeline is not storage. Every signal in A/B/C has an **exporter destination** that retains it. |
+
+---
+
+## 4. Constraints (environment)
+
+- Self-hosted (Coolify / Compose). Small team. Cost-sensitive: **SaaS OLAP meters** are the expensive thing; a single extra box is in play.
+- Redpanda already exists and must keep receiving the old topics (G4).
+- No Prometheus *server* today. No trace store today (Sentry only).
+- Volume unmeasured; PRD 20–40× events/impression is a hypothesis to *measure*, not a capacity spec.
+- Open source / public SDK: collection story must stay minimal and gated (PRD).
+
+---
+
+## 5. Explicitly not required in M0/M1
+
+- Publisher-facing dashboards, alerting *product*, partner portal.
+- Trace waterfall UI (store without Grafana is fine).
+- M2/M3 event catalog, OM definition (blocks `ad_impression` *meaning*, not `/show` as channel).
+- Cutting over old Kafka topics.
+- Server-minted `auction_id` (joint SDK change; correlate with what exists).
+- Replacing Redpanda as the ingest log.
+
+---
+
+## 6. What “a solution” has to be
+
+Minimum moving parts that satisfy §2–3:
+
+1. **A log** — already Redpanda — so producers stay fire-and-forget and G4 holds.  
+2. **A retained event table** — SQL-capable (or equivalent) for §2.A queries.  
+3. **A retained trace table or TSDB** — point-get by `trace_id` + duration quantiles for §2.B.  
+4. **An alert path** — may be rollups of (2) or (3), or a scrape of `/metrics`. Must not use `auction_id` as a series label.  
+5. **A collector** (or equivalent) that **exports** OTLP to (3) and optionally (4). Not optional if we want B.
+
+(2) and (3) **may be the same database** (different tables). (4) may be derived from (2)/(3) so you do not buy a TSDB. That is a *store-count* optimisation, not a requirement to merge grains.
+
+If you pick **one** database, it must still pass the §2.A funnel queries *and* §2.B point-get. If it fails either, it is not unified — it is the wrong one box.
+
+If you pick **two** (events vs traces), that is allowed. Three (events + traces + dedicated metrics TSDB) is justified when (4) cannot be derived from the lake inside the alert `for:` window — which is the Bidon M0 situation.
+
+---
+
+## 7. How to judge a candidate (sniff test)
+
+Ask, in order:
+
+1. Can I write the fill-rate SQL (or equivalent) with `sampling_rate`?  
+2. Can I load auction X’s span tree after a week?  
+3. Can I alert on DSP timeout rate without `auction_id` on the series?  
+4. Does `/show` billing still work if this store is down?  
+5. Can a small team back it up and notice it is empty (freshness)?  
+6. Is the cost **Cloud meter** or **one node**? Reject the former for M0 unless volume forces it.
+
+Anything that only answers 3 (classic PromQL TSDB) or only answers 2 (VictoriaTraces / Tempo) is a *component*, not the whole solution.
+
+---
+
+## 8. Open facts (not product choices)
+
+- Who consumes `ad-events` today.  
+- Direct-mode events per impression (measure).  
+- Whether `/v2/stats` `ad_units[]` is attempt-ordered (fill metrics).  
+- Impression definition vs OM (meaning of `ad_impression`).  
+- Legal retention for G3.
+
+Until those, capacity and monthly $ stay ranges, not a bill.
+
+---
+
+## 9. Events-only store (grain A)
+
+See [telemetry-events-store.md](./telemetry-events-store.md): **phased** — Parquet on S3 + DuckDB (Phase 1); Iceberg via OSS writer + REST catalog (Phase 2); Athena/Trino if needed (Phase 3); ClickHouse reads the **same** lake (Phase 4). No Redpanda Enterprise.
+
+---
+
+## 10. Traces store (grain B)
+
+See [telemetry-traces-store.md](./telemetry-traces-store.md): **VictoriaTraces** from day 1. OTLP via otelcol-contrib. GET by `trace_id`. Sentry exceptions only. Unbiased p95 / paging is grain C (spanmetrics), not this store.
+
+---
+
+## 11. Metrics store (grain C)
+
+See [telemetry-metrics-store.md](./telemetry-metrics-store.md): **VictoriaMetrics** from day 1. Scrape `/metrics` + OTel Prometheus exporter. vmalert + Alertmanager. No `auction_id` on series.

--- a/docs/telemetry-storage-recommendation.md
+++ b/docs/telemetry-storage-recommendation.md
@@ -1,0 +1,175 @@
+# Telemetry storage recommendation (historical)
+
+**Status:** SUPERSEDED as a decision. **Do not implement the unified-ClickHouse path below.** Kept for option history.
+
+**Current architecture:**
+
+| Grain | Store | Doc |
+| --- | --- | --- |
+| A events | Parquet / Iceberg lake + DuckDB | [telemetry-events-store.md](./telemetry-events-store.md) |
+| B traces | VictoriaTraces from day 1 | [telemetry-traces-store.md](./telemetry-traces-store.md) |
+| C metrics | VictoriaMetrics from day 1 | [telemetry-metrics-store.md](./telemetry-metrics-store.md) |
+
+Requirements: [telemetry-requirements.md](./telemetry-requirements.md). Spike architecture: [telemetry-m0-m1-backend-spike.md](./telemetry-m0-m1-backend-spike.md) §5. TRD: [TRD_BidOn_Telemetry.md](./TRD_BidOn_Telemetry.md) §6.
+
+**Date of this historical note:** 2026-08-20 (settled-isolation note: 2026-08-21)  
+**PRD:** [PRD_BidOn_Telemetry v1](./PRD_BidOn_Telemetry%20-%20v1.pdf)
+
+---
+
+## Why isolation was accepted
+
+The rest of this file argues that one self-hosted ClickHouse is *good enough at all three grains* and cheaper in *people* than three products. That is still true as a capability claim. It was **not** adopted. Isolation was a grain decision, not a claim that three stores use less CPU or are simpler to run.
+
+**Facts**
+
+- The three jobs are different access patterns: catalog SQL with `sampling_rate` and `auction_id`; point-get of a span tree by `trace_id`; `rate()` every minute on **low-cardinality** labels. `auction_id` is a row/attribute, not a Prom series label.
+- Alerts cannot wait on lake lag. Event SQL can. `/v2/show` does not query any of these stores; if a store is down, ads still serve.
+- Self-hosted ClickHouse OSS is licence $0, same as VM/VT/DuckDB. The meter we refused for M0 is **ClickHouse Cloud / SaaS OLAP**, not a CH licence. Victoria and Grafana also have paid SKUs later.
+- ClickHouse can do funnel SQL, `WHERE trace_id =`, and SQL `quantile`. VictoriaMetrics is PromQL/Alertmanager-native. VictoriaTraces is a GET-`trace_id` store. DuckDB runs **when someone queries** Parquet; it is not an always-on warehouse.
+- Three stores means three query languages, three Grafana datasources, three “is it empty?” checks, plus otelcol and a Parquet sink. One CH means one process, one language, background merges, and a heavy query sharing the ingest node.
+- At unmeasured Bidon M0 volume, **total RAM/CPU is not known to be smaller** for the split. Specialized engines are better-fit, not a guaranteed smaller machine. DuckDB-over-S3 will lose to CH if funnel SQL becomes daily/hourly and concurrent — that is events Phase 4 (CH **on the same lake**), not a redo of B or C.
+
+**Accepted trade-offs**
+
+| We took | We gave up |
+| --- | --- |
+| Each grain uses the engine that matches the query | One-box ops; one SQL pane |
+| PromQL + Alertmanager for paging (C) | SQL alerts on the event/trace store |
+| Event analytics off until query (A); traces GET in VT (B) | One backup, one on-call shape |
+| Failure isolation: lake sink or DuckDB stall does not stop paging; VT down does not stop `/show` or VM; a funnel query cannot starve alerts | More daemons, more freshness stories, more ways to be “half up” |
+| No Cloud OLAP meter in M0 | More people-time than one CH node (likely) |
+| CH later only if DuckDB is the bottleneck, same files | Not using CH’s ability to hold A+B+C in one process |
+
+Multiple failure domains are **both** a pro (blast radius) and a con (more to operate). That was accepted, not an accident of picking Victoria.
+
+Do not read the historical sections below as “isolation was the worse option.” They are the case for unification, which we declined.
+
+---
+
+## Historical recommendation (rejected)
+
+**Self-hosted ClickHouse (one node) is the store.** One SQL engine for product events, metric rollups, and traces. `otelcol-contrib` writes traces (and OTel metrics) into it; Redpanda `telemetry-events` lands in the same cluster (Kafka engine or a small consumer). Grafana optional. Sentry stays exceptions-only.
+
+ClickHouse **Cloud** is what is expensive. A single Coolify/Compose instance is not in the same cost class. The earlier three-store design (Parquet + VictoriaMetrics + VictoriaTraces) was an answer to “do not buy a warehouse SaaS,” not to “ClickHouse cannot query this.” If cost was the objection, self-host one node.
+
+Redpanda stays the ingest buffer and dual-emission path. It is not the query store.
+
+## Prometheus vs `/metrics` vs PromQL
+
+This repo **exposes** Prometheus *text* on `GET /metrics` (`echoprometheus`, OTel Prometheus exporter). That is a **client**. Nothing in this repo **scrapes or stores** those series. There is no Prometheus server unless Coolify/Grafana already added one outside the tree.
+
+So:
+
+- You do not “already have Prometheus” as a database.
+- You have a scrape endpoint. Without a scraper + TSDB, those numbers vanish on process restart.
+- **PromQL** is the query language of Prometheus-compatible TSDBs (Prometheus server, VictoriaMetrics, Mimir, …). Choosing VM means introducing that language *and* that store from zero.
+- Spanmetrics is a collector *connector*: it turns spans into Prometheus-format series. Those series still need an **exporter destination** (VM, Prometheus, or ClickHouse). The connector is not storage.
+
+## Collector
+
+Correct: the collector is a pipeline, not a store. Receive OTLP → batch/sample → **export**. No exporter ⇒ spans are dropped (after optional spanmetrics, which also need an exporter). M0 therefore needs a real trace backend. Sentry does not count.
+
+## Why three stores is the industry default — and why you can still use one
+
+The industry splits because the access patterns differ:
+
+| Job | Grain | Query |
+| --- | --- | --- |
+| Events (PRD catalog) | Row per event, `sampling_rate`, join `auction_id` | SQL funnels |
+| Metrics | Time series, low cardinality | Alert p95 / rates |
+| Traces | Span tree by `trace_id` | Fetch auction `abc`; latency per leg |
+
+Nothing is *best* at all three. **ClickHouse is the only widely used self-hosted system that is good enough at all three for Bidon’s PRD** (funnel SQL, `WHERE trace_id =`, histograms via `quantile` / materialized views). That is the SigNoz/HyperDX/ClickStack model: three *tables*, one process.
+
+VictoriaMetrics is better PromQL-native alerting. VictoriaTraces is a younger trace TSDB. Parquet+DuckDB is cheaper *if events are the only thing you store*. Together they are **three databases** (plus a sink). That is more RAM, more failure modes, and three query languages — the opposite of “least resistance” once you also need traces stored.
+
+## Cost, honestly
+
+| Option | Dollar cost at current scale | What you operate |
+| --- | --- | --- |
+| ClickHouse Cloud / Tinybird | High relative to Bidon M0 | Low ops, metered |
+| **ClickHouse one node** (Compose/Coolify, 4–8 GiB) | Disk + that VM; licence $0 | One datastore, backups, disk |
+| Parquet on R2 + DuckDB | Cheapest *events* | Sink + bucket; no always-on query |
+| VM + VT + Parquet | Three sets of RAM/disk | Three products + sink |
+
+If the CH objection is Cloud invoices: **do not buy Cloud.** One node next to Redpanda is the cost-controlled CH. It will likely be cheaper in *people* than VM+VT+lake, and similar in *machines* to VM+VT without solving events.
+
+Promotion later is more replicas / ClickHouse Cloud, not a new schema. Same tables.
+
+## What one ClickHouse instance actually does
+
+```
+bidon-sdkapi --OTLP--> otelcol-contrib --clickhouse exporter--> ClickHouse
+     |                                                      ▲
+     +-- telemetry-events --> Redpanda ---------------------+  (Kafka engine or consumer)
+```
+
+**Events.** MergeTree, partition `toDate(event_ts)`, `ORDER BY (event_name, auction_id, event_id)`. `sum(1 / sampling_rate)`. This is the PRD warehouse.
+
+**Traces.** Separate table `ORDER BY (trace_id, span_id)` (OTel exporter schema). Store sampled auction trees from M0 for baselines. Grafana trace UI later; SQL/`trace_id` lookup from day one. Head-sample success at a **known rate**; do not tail-sample if you want unbiased p95 from traces. Unbiased p95: `quantile` on span duration (or a MV), not “only the slow traces we kept.”
+
+**Metrics.** Two workable patterns — pick one:
+
+1. **SQL-only (fewer systems):** OTel metrics + materialized views from spans/events (`dsp_latency_ms` by `demand_id`). Grafana alert on SQL. You never introduce PromQL.
+2. **CH + PromQL:** still scrape `/metrics` into CH’s Prometheus-compatible endpoints *or* keep a tiny VM. Only do this if Grafana SQL alerts feel insufficient.
+
+Recommend **(1)** for a small team that did not want three stores. `/metrics` can keep existing for process health; funnel/DSP SLOs live in CH.
+
+**Spanmetrics** in the collector is optional if spans are in CH: you can aggregate in SQL. Spanmetrics is useful when the metric store is PromQL-native. With unified CH it is extra cardinality to manage, not a requirement.
+
+## Trade-offs of unified ClickHouse
+
+**Pros**
+
+- One query language (SQL) for fill rate, DSP timeout, notice failures, “show spans for `auction_id`.”
+- One backup, one disk, one on-call shape.
+- Matches the query the PRD actually needs; traces are stored, not only rolled up.
+- Files/export can still dump Parquet for icebox if you ever leave CH.
+- Collector has a first-class ClickHouse exporter.
+
+**Cons**
+
+- ClickHouse is a sharp tool: merges, partitions, `ORDER BY` mistakes hurt. A small team can run **one node** if one person owns schema; they cannot ignore it.
+- Trace waterfall UI is Grafana (or similar), not built-in. Storage does not require the UI.
+- Alerting is weaker than Alertmanager+PromQL until you invest in Grafana unified alerting.
+- A bad query can saturate the same node that is ingesting live auctions — isolate later (replicas) if that happens.
+- You still need Redpanda (have it) and the collector (exporter target = CH).
+
+## What you are not missing by skipping VM/VT (historical view)
+
+This section is the **rejected** unification case. We did start with VM/VT: PromQL paging and a dedicated trace GET were chosen, not left in a back pocket.
+
+VM/VT is a **vendor-shaped split**, not a requirement of the PRD. The historical argument: it is data-driven only if you already wanted PromQL and a dedicated trace TSDB; you do not have a Prometheus server today; one query surface points at CH. **We did want PromQL and a trace GET**, so that argument no longer applies.
+
+Historical close: “Keep Victoria in the back pocket if SQL alerts fail you. Do not start there to avoid CH Cloud.” We started there for grain fit, not to dodge a CH licence.
+
+## What Redpanda’s family actually covers
+
+You already run the useful part: the **bus**. The rest of the family helps **land events**, not replace ClickHouse as the unified query store.
+
+| Product | Helps | Does not |
+| --- | --- | --- |
+| **Redpanda (core)** | Buffer, replay, dual-emission, backpressure | Funnel SQL, traces, alerts |
+| **Console** | Inspect topics | Partner reports |
+| **Connect** (Benthos) | Sink `telemetry-events` → ClickHouse (or S3) without writing a consumer | OTLP from `bidon-sdkapi`; Connect’s `otlp_*` outputs *forward* OTel, they are not a trace database |
+| **Iceberg topics** | Broker writes the topic as Iceberg/Parquet in object storage — the lake without a hand-rolled sink | Query engine (you still point DuckDB/Spark/CH/Athena at the table); **not** traces or PromQL |
+| **Redpanda SQL** | Postgres-wire OLAP over live topic + Iceberg history | **Cloud BYOC**, not your Compose/Coolify node |
+| **Tiered storage** | Cheaper long Kafka retention on S3 | Analytics schema |
+
+Iceberg topics are the honest “use more Redpanda” move for **events**: enable Iceberg on `telemetry-events`, get Parquet in the bucket, query with DuckDB or let ClickHouse read Iceberg. Production Iceberg is aimed at BYOC/Enterprise + object storage; your current `docker-compose.dev.yml` Redpanda is a plain broker. Treat Iceberg as an upgrade path once Coolify Redpanda has a bucket, not as free on today’s container.
+
+Still required outside the family: **OTLP collector + a trace (and metric) store**. Redpanda will not become VictoriaTraces or a PromTSDB. Putting spans on a Kafka topic and calling it traces leaves you scanning a log, not `GET trace_id`.
+
+**Least resistance with what you have:** keep Redpanda as ingest; use **Connect → ClickHouse** (or Iceberg later) for events; collector → same ClickHouse for traces. That is “more Redpanda” where it is good (pipeline), one database where you query.
+
+## Path (historical — do not follow)
+
+1. **M0:** One ClickHouse; otelcol-contrib → CH traces (sampled); `telemetry-events` → CH; dual-emit old Kafka topics; Sentry traces off the auction path. No Cloud. No VM/VT. No Parquet sink unless you want a second copy for safety.
+2. **Alerts:** Grafana (or CH `system.query_log` + a cron) on DSP p95 / ingest failures. Add `/metrics` scrape into CH only if process metrics are not already in OTel.
+3. **M1:** Same tables, more event names. Auction/DSP spans (BE-M0-6) make the trace table match the TRD tree.
+4. **Scale tripwire:** disk merge pressure, query vs ingest contention, or multi-month retention at tens of millions of rows/day → replica or Cloud. Schema stays.
+
+## Stability (historical)
+
+The rejected M0 was: events and sampled traces **queryable in one ClickHouse**, billing still on `/show`, old `ad-events` still flowing, collector exporting to CH not Sentry. **Settled M0 is the three-grain architecture** in the spike §5 / TRD §6 (not implemented in this repo yet).

--- a/docs/telemetry-traces-store.md
+++ b/docs/telemetry-traces-store.md
@@ -1,0 +1,130 @@
+# Operational traces: VictoriaTraces from day 1
+
+**Scope:** grain B only ([telemetry-requirements.md](./telemetry-requirements.md) §2.B). Grain A: [telemetry-events-store.md](./telemetry-events-store.md). Grain C: [telemetry-metrics-store.md](./telemetry-metrics-store.md). Spike architecture: [telemetry-m0-m1-backend-spike.md](./telemetry-m0-m1-backend-spike.md) §5.
+
+**Decision:** export OTLP from `bidon-sdkapi` via **otelcol-contrib** into **single-node VictoriaTraces**. GET the tree by `trace_id` (Jaeger API; Tempo HTTP API when useful). Grafana later, optional. **Spanmetrics → VictoriaMetrics** for unbiased p95 and paging. **Sentry stays exceptions only.** Cluster VT only if one node hurts. Backup/`vmbackup`-style copy to S3 when local disk is not enough — VT is not a live Parquet lake.
+
+These are **phased**. Each phase keeps the produce path: OTel SDK, never await from the ad path.
+
+`/v2/show` does not query VT. If VT is down, ads still serve; you just cannot load the tree (G1/G2).
+
+---
+
+## Argument
+
+A trace is a **point lookup** (auction X’s DSP legs), not funnel SQL and not a Prom series. Events can sit unread on S3; traces can sit unread on **local VT disk** until someone GETs them. Paging cannot wait on that GET — that is why p95 lives in **VictoriaMetrics**.
+
+We already run **VictoriaMetrics** for grain C. VictoriaTraces is the same-family ops shape: one vendor, OTLP in, local storage, Grafana datasources later, cluster when needed. It is **not** Tempo’s Parquet-on-S3 model. That trade was explicit: family over lake physics.
+
+Do not put `auction_id` on a **metric** label. On a span it is an **attribute** so events and traces join.
+
+---
+
+## Same model as events / metrics
+
+| Event lake (A) | Metrics (C) | Traces (B) |
+| --- | --- | --- |
+| Produce JSON, do not await the warehouse | Increment counters, do not await VM | Export OTLP, do not await VT |
+| Redpanda is the durable log | VM local storage is the hot WAL | VT local storage is the retain |
+| Parquet on S3 is the cheap retain | `vmbackup` to S3 later | **Backup to S3 later** (not live GET-from-Parquet) |
+| DuckDB when a human runs SQL | MetricsQL when vmalert runs | **GET `trace_id`** when a human debugs |
+| Iceberg when engines need a catalog | VM cluster when one node hurts | **VT cluster** when one node hurts |
+| ClickHouse later as SQL accelerator | Do not add CH for metrics | Do not add CH *only* for traces |
+
+**What transfers from events:** debugging is on-demand. No always-on PromQL.
+
+**What does not transfer:** DuckDB `WHERE trace_id =` on the event lake is a full scan. VT exists so GET is an index lookup. Redpanda is the **event** log; OTLP is the trace wire.
+
+---
+
+## How traces are born (produce)
+
+The auction path never blocks on VT.
+
+```
+bidon-sdkapi (OTel SDK) → otelcol-contrib
+                            → OTLP exporter → VictoriaTraces
+                            → spanmetrics connector → VictoriaMetrics
+```
+
+| Span | Parent | Attributes (keep useful, not huge) |
+| --- | --- | --- |
+| `auction.run` | HTTP `/v2/auction` | `auction_id`, `app_id`, `ad_type` |
+| `auction.dsp.{demand_id}` | `auction.run` | `demand_id`, `http.status`, `outcome` |
+| `notification.send` | `auction.run` or `/v2/show` | `notice_type`, `demand_id`, `http.status` |
+
+Head-sample at a **known** rate (or errors + a fraction of successes). Record the rate. Tail sampling (“keep only slow”) is allowed for extra debug volume; then **do not** use this store for p95.
+
+Collector is a pipe. No exporter destination ⇒ spans are dropped (G9).
+
+**Already in the repo:** `ConfigureOTel()` sends spans to **Sentry**. Auction traces must not dual-write there.
+
+---
+
+## Phases
+
+### Phase 1 — single-node VT (M0, day 1)
+
+```
+otelcol → VictoriaTraces (single)
+            → GET /select/jaeger/api/traces/{trace_id}
+            → Grafana later (Jaeger or Tempo datasource → VT)
+```
+
+- Compose/Coolify sidecar. Local disk. Retention sized to sampled auction trees, not every span forever.
+- Query: Jaeger JSON API from day one. Tempo HTTP API is experimental on VT — fine for Grafana later, not a blocker.
+- Prove B: load auction X’s tree via `trace_id` (and `auction_id` as a tag/attribute filter). No UI required.
+
+### Phase 2 — cold copy on object storage (when local disk is not enough)
+
+Backup VT data to `s3://…/traces/` (same bucket family as events, different prefix). Disaster recovery / capacity, not a live trace-lake. GETs still hit **Phase 1**.
+
+Not Tempo S3 blocks. Not Iceberg of spans. Not spans on `telemetry-events`.
+
+### Phase 3 — VT cluster (only if ingest or lookup hurts)
+
+`vtinsert` / `vtselect` / `vtstorage`. Skip until one node is the problem.
+
+---
+
+## What we are not doing
+
+| Skip | Why |
+| --- | --- |
+| Prometheus / Tempo *server* as the trace store | VT from day 1; same family as VM |
+| Sentry as the auction trace backend | Not queryable for reports; exceptions only |
+| Spans on `telemetry-events` / DuckDB `WHERE trace_id` | Wrong grain; full scan |
+| Grafana Cloud Tempo / Honeycomb / Datadog | Metered SaaS |
+| Jaeger + Elasticsearch / Cassandra | Index database you do not want to run |
+| ClickHouse traces table | Unified-CH was rejected for A and C |
+| Tempo metrics-generator **and** collector spanmetrics | One rollup into VM; collector spanmetrics is enough |
+| High-cardinality Prom labels | `auction_id` stays a span attribute |
+| Tail-sample-only traces used as p95 | Biased; p95 lives in VM |
+
+---
+
+## Relationship to A and C
+
+- **A:** “what was fill rate last week” — SQL on Parquet. Join VT via `auction_id` when a row is interesting.
+- **B (this doc):** “show me auction X’s DSP legs.”
+- **C:** “is DSP timeout rate bad *right now*” — VM. Spanmetrics rolls B → C without ids on series.
+
+Three grains can share **one Grafana**. Events share a bucket with optional VT backups (`events/`, `metrics/`, `traces/`). They do not share one table format.
+
+---
+
+## Decision
+
+| Item | Choice |
+| --- | --- |
+| Store | Single-node **VictoriaTraces**, OTLP from otelcol-contrib |
+| Lookup | Jaeger API GET by `trace_id`; `auction_id` as span attribute |
+| p95 / paging | **VictoriaMetrics** via spanmetrics, not this store |
+| UI | Optional; API GET is M0 |
+| Cold copy (optional) | Backup to S3 `traces/` prefix |
+| Scale-up | VT cluster, not CH-for-traces, not Tempo |
+| Not the event topic | Do not write spans to `telemetry-events` |
+| Not Sentry | Exceptions only |
+| Sample | Known head rate; tail-sample only for extra debug volume |
+
+Owners still needed: who runs the VT instance, head-sample policy, and Sentry config so auction trees stop going there.


### PR DESCRIPTION
## Summary

Discovery-only docs for the backend side of telemetry M0/M1 ([BAC-53](https://linear.app/bidon/issue/BAC-53/backend-telemetry-m0m1-discovery-and-store-research)). No production instrumentation.

This inventory maps what `bidon-sdkapi` already emits (`ad-events`, `notification-events`, `/v2/show` + BURL) onto the PRD catalog, splits three data grains, and settles stores. Dual-emit the old Kafka topics until the current consumer is named and migrated.

### Settled stores

| Grain | Job | Store |
| --- | --- | --- |
| **A** Product events | Catalog SQL (`sampling_rate`, join `auction_id`) | Redpanda `telemetry-events` → Parquet/Iceberg → DuckDB |
| **B** Traces | Per-auction span tree (`GET` by `trace_id`) | OTLP → VictoriaTraces |
| **C** Metrics / alerts | Page if X is bad for N minutes | VictoriaMetrics (scrape `/metrics` + spanmetrics) |

`/v2/show` produces impression + BURL. It does not query any of these stores. `auction_id` is a row/span attribute, not a Prom series label.

Isolation is a grain decision (better fit per job, PromQL paging, blast-radius isolation, no Cloud OLAP meter in M0). It is not a claim that three stores use less compute than one ClickHouse node. Unified ClickHouse is recorded as a rejected option in the historical storage note. ClickHouse later is events Phase 4 on **the same lake**, not a redo of B or C.

### Docs in this PR

- `docs/telemetry-m0-m1-backend-spike.md` — current pipeline, PII, dual-emit, architecture, BE-M0/M1 ticket list (days TBC)
- `docs/telemetry-requirements.md` — jobs, grains, guarantees
- `docs/telemetry-events-store.md` — grain A
- `docs/telemetry-traces-store.md` — grain B
- `docs/telemetry-metrics-store.md` — grain C
- `docs/telemetry-storage-recommendation.md` — superseded unified-CH notes; why isolation was accepted

### Not in this PR

- PRD and backend TRD (kept private)
- Compose/Coolify for VM, VT, otelcol, or the Parquet sink
- Filing BE-M0/M1 implementation tickets

Related SDK review: [BID-54](https://linear.app/bidon/issue/BID-54/sdk-telemetry), [BID-46](https://linear.app/bidon/issue/BID-46/telemetry-event-parameters), [BID-47](https://linear.app/bidon/issue/BID-47/telemetry-delivery-and-configuration).

## Test plan

- [ ] Read the spike architecture (§5) and confirm it matches the three store docs
- [ ] Confirm PRD PDF and `docs/TRD_BidOn_Telemetry.md` are **not** in the diff
- [ ] No Go/runtime changes; `make test` not required for this PR


Made with [Cursor](https://cursor.com)